### PR TITLE
Fixed logic in Deathball's updateRollAnimation

### DIFF
--- a/modules/DeathBallToy/1/main.cs
+++ b/modules/DeathBallToy/1/main.cs
@@ -210,7 +210,7 @@ function DeathBallToy::spawnDeathball(%this, %position)
     
     //%db.pauseAnimation(1);
 
-    //Deathball.rollSchedule = Deathball.schedule(100, "updateRollAnimation");
+    Deathball.rollSchedule = Deathball.schedule(100, "updateRollAnimation");
 
     SandboxScene.add(%db);
 
@@ -224,13 +224,10 @@ function Deathball::updateRollAnimation(%this)
     %this.rollSchedule = "";
 
     %velocity = %this.getLinearVelocity();
-
-    %currentAnimTime = %this.getAnimationTime();
     %scaledVelocity = (mAbs(getWord(%velocity, 0))) + mAbs(getWord(%velocity, 1)) / 50;
     %flooredVelocity = mFloatLength(%scaledVelocity, 1);
-    %scaledAnimTime = %currentAnimTime * %flooredVelocity;
 
-    %this.setAnimationTimeScale(%scaledAnimTime);
+    %this.setAnimationTimeScale(%flooredVelocity / 15);
 
     %this.rollSchedule = %this.schedule(100, updateRollAnimation);
 }


### PR DESCRIPTION
Previously, there was some odd logic that made the animation speed up incredibly fast, eventually hitting `inf` and crashing the engine. This fixes the script-side issue; perhaps there should be some code-side checks in place to stop this sort of thing happening. (In this case, `setAnimationTimescale` was accepting an infinite value from scripts.)

Anyway, I just wanted to see the deathball speed up as I crushed the poor little soldiers. Now it does. Enjoy.
