### PR TITLE
"Cannot assign a zero batch Id." When clearing and adding sprites to a CompositeSprite

### DIFF
--- a/engine/source/2d/core/SpriteBatch.cc
+++ b/engine/source/2d/core/SpriteBatch.cc
@@ -931,7 +931,7 @@ SpriteBatchItem* SpriteBatch::createSprite( void )
     PROFILE_SCOPE(SpriteBatch_CreateSprite);
 
     // Allocate batch Id.
-    const U32 batchId = mMasterBatchId++;
+    const U32 batchId = ++mMasterBatchId;
 
     // Create sprite batch item,
     SpriteBatchItem* pSpriteBatchItem = SpriteBatchItemFactory.createObject();


### PR DESCRIPTION
Oops. I think I choose the wrong destination and wrong source...

Anyway,
a fatal error occurs when 'mMasterBatch' is equal to zero when adding a
new sprite to a CompositeSprite. Calling the 'ClearSprites' function
sets 'mMasterBatch' to zero and the very next sprite added has batchId
equal to zero causing an error because the '++' came to late. Putting
the '++' in front of 'mMasterBatchId' when initializing 'batchId'
ensures that the 'batchId' is never zero.
