### PR TITLE
onCollision version with parameters that are "backward compatible" with ...

### DIFF
--- a/engine/source/2d/scene/Scene.cc
+++ b/engine/source/2d/scene/Scene.cc
@@ -566,8 +566,8 @@ void Scene::dispatchBeginContactCallbacks( void )
             else
             {
                 // No, so call it on its behaviors.
-                const char* args[5] = { "onCollision", "", sceneObjectABuffer, sceneObjectBBuffer, miscInfoBuffer };
-                pSceneObjectA->callOnBehaviors( 5, args );
+                const char* args[4] = { "onCollision", "", sceneObjectBBuffer, miscInfoBuffer };
+                pSceneObjectA->callOnBehaviors( 4, args );
             }
         }
 
@@ -586,8 +586,8 @@ void Scene::dispatchBeginContactCallbacks( void )
             else
             {
                 // No, so call it on its behaviors.
-                const char* args[5] = { "onCollision", "", sceneObjectBBuffer, sceneObjectABuffer, miscInfoBuffer };
-                pSceneObjectB->callOnBehaviors( 5, args );
+                const char* args[4] = { "onCollision", "", sceneObjectABuffer, miscInfoBuffer };
+                pSceneObjectB->callOnBehaviors( 4, args );
             }
         }
     }
@@ -678,8 +678,8 @@ void Scene::dispatchEndContactCallbacks( void )
             else
             {
                 // No, so call it on its behaviors.
-                const char* args[5] = { "onEndCollision", "", sceneObjectABuffer, sceneObjectBBuffer, miscInfoBuffer };
-                pSceneObjectA->callOnBehaviors( 5, args );
+                const char* args[4] = { "onEndCollision", "", sceneObjectBBuffer, miscInfoBuffer };
+                pSceneObjectA->callOnBehaviors( 4, args );
             }
         }
 
@@ -698,8 +698,8 @@ void Scene::dispatchEndContactCallbacks( void )
             else
             {
                 // No, so call it on its behaviors.
-                const char* args[5] = { "onEndCollision", "", sceneObjectBBuffer, sceneObjectABuffer, miscInfoBuffer };
-                pSceneObjectB->callOnBehaviors( 5, args );
+                const char* args[4] = { "onEndCollision", "", sceneObjectABuffer, miscInfoBuffer };
+                pSceneObjectB->callOnBehaviors( 4, args );
             }
         }
     }


### PR DESCRIPTION
There is an open question as to how to best handle onCollision in behaviors.

Say two objects A and B collide.  T2D has the option to handle onCollision with either the Scene or with the objects themselves.  If handling with the scene, you have

```
myScene::onCollision(%this, %objectA, %objectB, %details)
```

where you get both objects, of course.  If handling with the objects themselves, you have

```
myObject::onCollision(%this, %objectB, %details)`
```

The called object is objectA or `%this`.  The question is if handling with behaviors, what do you prefer?  Original it was

```
1) myBehavior::onCollision(%this, %objectB, %details)
```

That is, to get objectA,  you use `%this.owner`.  A recent experiment changed it to

```
2) myBehavior::onCollision(%this, %parentObjectA, %objectB, %details)
```

That is, you also get the owner (objectA) directly as `%parentObjectA`.

Opinions?  Don't cares?

The current pull request would switch it back to 1) above.  Canceling this pull request would keep it at the new 2).
