### PR TITLE
Fix OSX-Debug rapidjson header include

### DIFF
--- a/engine/compilers/Xcode/Torque2D.xcodeproj/project.pbxproj
+++ b/engine/compilers/Xcode/Torque2D.xcodeproj/project.pbxproj
@@ -3543,7 +3543,7 @@
 					../../lib/lpng,
 					../../lib/ljpeg,
 					../../lib/lungif,
-					../../source/persistence/rapidjson,
+					../../source/persistence/rapidjson/include,
 					../../source/testing/googleTest,
 					../../source/testing/googleTest/include,
 					"$(SYSTEM_LIBRARY_DIR)/Frameworks/ApplicationServices.framework/Versions/Current/Frameworks/QD.framework/Headers",


### PR DESCRIPTION
Just a quick build fix to the OSX-Debug header search directories
