### PR TITLE
ParticleAsset/Emitter/Player TorqueScript additions

### DIFF
--- a/engine/source/2d/assets/ParticleAsset.cc
+++ b/engine/source/2d/assets/ParticleAsset.cc
@@ -130,7 +130,7 @@ ParticleAsset::ParticleAsset() :
     VECTOR_SET_ASSOCIATION( mEmitters );  
 
     // Initialize particle fields.
-    mParticleFields.addField( mParticleLifeScale.getBase(), "LifeScale", 1000.0f, 0.0f, 100.0f, 1.0f );
+    mParticleFields.addField( mParticleLifeScale.getBase(), "LifetimeScale", 1000.0f, 0.0f, 100.0f, 1.0f );
     mParticleFields.addField( mQuantityScale.getBase(), "QuantityScale", 1000.0f, 0.0f, 100.0f, 1.0f );
     mParticleFields.addField( mSizeXScale.getBase(), "SizeXScale", 1000.0f, 0.0f, 100.0f, 1.0f );
     mParticleFields.addField( mSizeYScale.getBase(), "SizeYScale", 1000.0f, 0.0f, 100.0f, 1.0f );

--- a/engine/source/2d/assets/ParticleAssetEmitter_ScriptBinding.h
+++ b/engine/source/2d/assets/ParticleAssetEmitter_ScriptBinding.h
@@ -75,6 +75,107 @@ ConsoleMethod(ParticleAssetEmitter, getEmitterType, const char*, 2, 2,  "() Gets
 
 //-----------------------------------------------------------------------------
 
+ConsoleMethod(ParticleAssetEmitter, setEmitterOffset, void, 3, 4,   "(float X / float Y) - Offsets the position of the emitter relative to the effect or player position.\n"
+                                                                    "@return No return value.")
+{
+    // Grab the element count.
+    U32 elementCount =Utility::mGetStringElementCount(argv[2]);
+    
+    // ("positionX positionY")
+    if ( (elementCount == 2) && (argc < 4) )
+    {
+        object->setEmitterOffset( Vector2( argv[2] ) );
+        return;
+    }
+    
+    // (positionX, positionY)
+    if ( (elementCount == 1) && (argc > 3) )
+    {
+        object->setEmitterOffset( Vector2( dAtof(argv[2]), dAtof(argv[3]) ) );
+        return;
+    }
+    
+    // Warn.
+    Con::warnf( "ParticleAssetEmitter::setEmitterOffset() - Invalid number of parameters!" );
+}
+
+//------------------------------------------------------------------------------
+
+ConsoleMethod(ParticleAssetEmitter, getEmitterOffset, const char*, 2, 2,    "Gets the emitter offset position.\n"
+                                                                            "@return (float x/float y) The offset of the emitter relative to the effect or player position.")
+{
+    return object->getEmitterOffset().scriptThis();
+}
+
+//------------------------------------------------------------------------------
+
+ConsoleMethod(ParticleAssetEmitter, setEmitterSize, void, 3, 4, "(float width / float height) - Sets the emitter size.\n"
+                                                                "@param width The width of the emitter.\n"
+                                                                "@param height The height of the emitter.\n"
+                                                                "@return No return value.")
+{
+    F32 width, height;
+    
+    const U32 elementCount = Utility::mGetStringElementCount(argv[2]);
+    
+    // ("width height")
+    if ((elementCount == 2) && (argc == 3))
+    {
+        width = dAtof(Utility::mGetStringElement(argv[2], 0));
+        height = dAtof(Utility::mGetStringElement(argv[2], 1));
+    }
+    
+    // (width, [height])
+    else if (elementCount == 1)
+    {
+        width = dAtof(argv[2]);
+        
+        if (argc > 3)
+            height = dAtof(argv[3]);
+        else
+            height = width;
+    }
+    
+    // Invalid
+    else
+    {
+        Con::warnf("ParticleAssetEmitter::setEmitterSize() - Invalid number of parameters!");
+        return;
+    }
+    
+    // Set Size.
+    object->setEmitterSize(Vector2(width, height));
+}
+
+//------------------------------------------------------------------------------
+
+ConsoleMethod(ParticleAssetEmitter, getEmitterSize, const char*, 2, 2,  "Gets the emitter size.\n"
+                                                                        "@return (float width/float height) The width and height of the emitter.")
+{
+    return object->getEmitterSize().scriptThis();
+}
+
+//------------------------------------------------------------------------------
+
+ConsoleMethod(ParticleAssetEmitter, setEmitterAngle, void, 3, 3,    "(float angle) - Sets the emitter angle.\n"
+                                                                    "@param angle The angle of the emitter."
+                                                                    "@return No return value.")
+{
+    // Set Rotation.
+    object->setEmitterAngle( mDegToRad( dAtof(argv[2]) ) );
+}
+
+//-----------------------------------------------------------------------------
+
+ConsoleMethod(ParticleAssetEmitter, getEmitterAngle, F32, 2, 2, "() Gets the emitter angle.\n"
+                                                                "@return (float angle) The emitter's current angle.")
+{
+    // Return angle.
+    return mRadToDeg( object->getEmitterAngle());
+}
+
+//-----------------------------------------------------------------------------
+
 ConsoleMethod(ParticleAssetEmitter, setFixedAspect, void, 3, 3,     "(fixedAspect) Sets the emitter to used a fixed-aspect for particles.\n"
                                                                     "@param fixedAspect Whether to use a fixed-aspect or not.\n"
                                                                     "@return No return value." )
@@ -362,6 +463,23 @@ ConsoleMethod(ParticleAssetEmitter, getImageFrame, S32, 2, 2,    "() Gets the as
 }
 
 //------------------------------------------------------------------------------
+
+ConsoleMethod(ParticleAssetEmitter, setRandomImageFrame, void, 3, 3,    "(randomImageFrame) Disables the Frame field and uses a random frame from the specified ImageAsset.\n"
+                                                                        "@param randomImageFrame Whether to use a random image frame or not.\n"
+                                                                        "@return No return value." )
+{
+    object->setRandomImageFrame( dAtob(argv[2]) );
+}
+
+//------------------------------------------------------------------------------
+
+ConsoleMethod(ParticleAssetEmitter, getRandomImageFrame, bool, 2, 2,    "() Gets whether a random frame from the specified ImageAsset is being used or not.\n"
+                                                                        "@return Whether to use a random image frame or not." )
+{
+    return object->getRandomImageFrame();
+}
+
+//-----------------------------------------------------------------------------
 
 ConsoleMethod(ParticleAssetEmitter, setAnimation, bool, 3, 3,   "(animationAssetId) Sets the emitter to use the specified animation asset Id.\n"
                                                                 "@param animationAssetId The animation asset Id to use.\n"

--- a/engine/source/2d/sceneobject/ParticlePlayer_ScriptBinding.h
+++ b/engine/source/2d/sceneobject/ParticlePlayer_ScriptBinding.h
@@ -54,6 +54,22 @@ ConsoleMethod(ParticlePlayer, getCameraIdleDistance, F32, 2, 2,     "() Gets the
 
 //-----------------------------------------------------------------------------
 
+ConsoleMethod(ParticlePlayer, setParticleInterpolation, void, 3, 3,     "(bool status) Sets whether the intermediate world position, rotation, and size data points of particles between ticks are calculated.\n"
+                                                                        "@return No return value.")
+{
+    object->setParticleInterpolation( dAtof(argv[2]) );
+}
+
+//-----------------------------------------------------------------------------
+
+ConsoleMethod(ParticlePlayer, getParticleInterpolation, F32, 2, 2,  "() Gets whether the intermediate world position, rotation, and size data points of particles between ticks are calculated.\n"
+                                                                    "@return (bool status) Whether interpolation is calculated or not.")
+{
+    return object->getParticleInterpolation();
+}
+
+//-----------------------------------------------------------------------------
+
 ConsoleMethod(ParticlePlayer, setEmissionRateScale, void, 3, 3,     "(scale) Sets the scale for the particle player emission rate.\n"
                                                                     "@param scale The scale for the particle player emission rate.\n"
                                                                     "@return No return value.")
@@ -101,6 +117,22 @@ ConsoleMethod(ParticlePlayer, getForceScale, F32, 2, 2,     "() Gets the scale f
                                                             "@return The scale for the particle player forces.")
 {
     return object->getForceScale();
+}
+//-----------------------------------------------------------------------------
+
+ConsoleMethod(ParticlePlayer, setTimeScale, void, 3, 3,     "(scale) Sets the scale for the particle player particle lifetimes.\n"
+                                                            "@param scale The scale for the particle player particle lifetimes.\n"
+                                                            "@return No return value.")
+{
+    object->setTimeScale( dAtof(argv[2]) );
+}
+
+//-----------------------------------------------------------------------------
+
+ConsoleMethod(ParticlePlayer, getTimeScale, F32, 2, 2,  "() Gets the scale for the particle player particle lifetimes.\n"
+                                                        "@return The scale for the particle player particle lifetimes.")
+{
+    return object->getTimeScale();
 }
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
- Changed ParticleAsset "LifeScale" field to "LifetimeScale" to match
  base and variation graph field naming convention for particle life
- Added missing TorqueScript bindings to certain fields for
  ParticleAssetEmitter and ParticlePlayer
