### PR TITLE
Final CompositeSprite Fix.

### DIFF
--- a/engine/source/2d/core/SpriteBatchItem.h
+++ b/engine/source/2d/core/SpriteBatchItem.h
@@ -291,6 +291,7 @@ public:
 
     virtual void copyTo( SpriteBatchItem* pSpriteBatchItem ) const;
 
+    inline const Vector2* getLocalOOBB( void ) const { return mLocalOOBB; }
     inline const Vector2* getRenderOOBB( void ) const { return mRenderOOBB; }
 
     void prepareRender( SceneRenderRequest* pSceneRenderRequest, const U32 batchTransformId );

--- a/engine/source/2d/core/SpriteBatchQuery.cc
+++ b/engine/source/2d/core/SpriteBatchQuery.cc
@@ -81,6 +81,30 @@ bool SpriteBatchQuery::update( SpriteBatchItem* pSpriteBatchItem, const b2AABB& 
 
 //-----------------------------------------------------------------------------
 
+U32 SpriteBatchQuery::queryOOBB( const b2AABB& aabb, b2PolygonShape& oobb, const bool targetOOBB )
+{
+  // This function is used exclusively when picking rectangular areas using CompositeSprite's pickArea ConsoleMethod
+  // For rendering, SpriteBatchQuery::queryArea is used instead
+
+  // Debug Profiling.
+    PROFILE_SCOPE(SpriteBatchQuery_QueryArea);
+
+    mMasterQueryKey++;
+
+    // Flag as not a ray-cast query result.
+    mIsRaycastQueryResult = false;
+
+  mComparePolygonShape.Set(oobb.m_vertices,4);
+  mComparePolygonShape.m_centroid = oobb.m_centroid;
+
+    mCompareTransform.SetIdentity();
+    mCheckOOBB = targetOOBB;
+    Query( this, aabb );
+    mCheckOOBB = false;
+
+    return getQueryResultsCount();
+}
+
 U32 SpriteBatchQuery::queryArea( const b2AABB& aabb, const bool targetOOBB )
 {
     // Debug Profiling.
@@ -195,7 +219,7 @@ bool SpriteBatchQuery::QueryCallback( S32 proxyId )
     {
             // Fetch the shapes render OOBB.
         b2PolygonShape oobb;
-        oobb.Set( pSpriteBatchItem->getRenderOOBB(), 4);
+        oobb.Set( pSpriteBatchItem->getLocalOOBB(), 4);
 
         if ( mCheckPoint )
         {
@@ -237,7 +261,7 @@ F32 SpriteBatchQuery::RayCastCallback( const b2RayCastInput& input, S32 proxyId 
     {
         // Fetch the shapes render OOBB.
         b2PolygonShape oobb;
-        oobb.Set( pSpriteBatchItem->getRenderOOBB(), 4);
+        oobb.Set( pSpriteBatchItem->getLocalOOBB(), 4);
         b2RayCastOutput rayOutput;
         if ( !oobb.RayCast( &rayOutput, mCompareRay, mCompareTransform, 0 ) )
             return true;

--- a/engine/source/2d/core/SpriteBatchQuery.h
+++ b/engine/source/2d/core/SpriteBatchQuery.h
@@ -50,6 +50,7 @@ public:
 
     //// Spatial queries.
     U32             queryArea( const b2AABB& aabb, const bool targetOOBB );
+    U32             queryOOBB( const b2AABB& aabb, b2PolygonShape& oobb, const bool targetOOBB );
     U32             queryRay( const Vector2& point1, const Vector2& point2, const bool targetOOBB );
     U32             queryPoint( const Vector2& point, const bool targetOOBB );
  


### PR DESCRIPTION
PickPoint, PickArea and PickRay now work in all scenarios, regardless of CompositeSprite position, rotation or camera zoom level.
