### PR TITLE
ImageWidth and ImageHeight were inverted in calculateImage function

### DIFF
--- a/engine/source/2d/assets/ImageAsset.cc
+++ b/engine/source/2d/assets/ImageAsset.cc
@@ -999,7 +999,7 @@ void ImageAsset::calculateImplicitMode( void )
     }
 
     // The cell height needs to be at maximum the image height!
-    if ( mCellHeight < 1 || mCellHeight > imageWidth )
+    if ( mCellHeight < 1 || mCellHeight > imageHeight )
     {
         // Warn.
         Con::warnf("ImageAsset::calculateImage() - Invalid Cell Height of %d.", mCellHeight );
@@ -1015,7 +1015,7 @@ void ImageAsset::calculateImplicitMode( void )
     }
 
     // The Cell Offset Y needs to be within the image.
-    if ( mCellOffsetY < 0 || mCellOffsetY >= imageWidth )
+    if ( mCellOffsetY < 0 || mCellOffsetY >= imageHeight )
     {
         // Warn.
         Con::warnf("ImageAsset::calculateImage() - Invalid Cell OffsetY of %d.", mCellOffsetY );


### PR DESCRIPTION
Simple Typo. Fixed.
