### PR TITLE
Fix Issue #42: Better document createPath()

### DIFF
--- a/engine/source/platformWin32/winFileio.cc
+++ b/engine/source/platformWin32/winFileio.cc
@@ -715,21 +715,12 @@ bool Platform::getFileTimes(const char *filePath, FileTime *createTime, FileTime
 }
 
 //--------------------------------------
-bool Platform::createPath(const char *infile)
+bool Platform::createPath(const char *file)
 {
-   char fixedFile[1024];
-   const char *file = fixedFile;
    char pathbuf[1024];
    const char *dir;
    pathbuf[0] = 0;
    U32 pathLen = 0;
-
-   // make sure the infile always ends with '/'.  this will
-   // simplify the loop below.  create this condition by copying
-   // the infile to a new buffer and possibly appending '/' to it.
-   dStrcpy(fixedFile, infile);
-   if (fixedFile[dStrlen(file)-1] != '/')
-      dStrcat(fixedFile, "/");
 
    while((dir = dStrchr(file, '/')) != NULL)
    {

--- a/engine/source/platformX86UNIX/x86UNIXFileio.cc
+++ b/engine/source/platformX86UNIX/x86UNIXFileio.cc
@@ -844,20 +844,11 @@ bool dPathCopy(const char *fromName, const char *toName, bool nooverwrite)
  //-----------------------------------------------------------------------------
  bool Platform::createPath(const char *file)
  {
-    char fixedFile[1024];
-    const char *file = fixedFile;
     char pathbuf[MaxPath];
     const char *dir;
     pathbuf[0] = 0;
     U32 pathLen = 0;
  
-   // make sure the infile always ends with '/'.  this will
-   // simplify the loop below.  create this condition by copying
-   // the infile to a new buffer and possibly appending '/' to it.
-   dStrcpy(fixedFile, infile);
-   if (fixedFile[dStrlen(file)-1] != '/')
-      dStrcat(fixedFile, "/");
-
     // all paths should be created in home directory
     char prefPathName[MaxPath];
     MungePath(prefPathName, MaxPath, file, GetPrefDir());


### PR DESCRIPTION
After many backs and forths on #42, the final code change is simply to update the comments to better understand what createPath() does (not) do.

If a "path" ends in a non-slash, then the final component of the path is assumed to not be a part of that path.  So, `a/b/c` will create a path `a/b` and assume c is a file name.  On the other hand `a/b/c/` will create all 3 path components.
