### PR TITLE
Replaced call to makeFullPathName to expandPath

### DIFF
--- a/engine/source/graphics/TextureManager.cc
+++ b/engine/source/graphics/TextureManager.cc
@@ -891,7 +891,7 @@ TextureObject *TextureManager::loadTexture(const char* pTextureKey, TextureHandl
 GBitmap *TextureManager::loadBitmap( const char* pTextureKey, bool recurse, bool nocompression )
 {
     char fileNameBuffer[512];
-    Platform::makeFullPathName( pTextureKey, fileNameBuffer, 512 );
+    Con::expandPath( fileNameBuffer, sizeof(fileNameBuffer), pTextureKey );
     GBitmap *bmp = NULL;
 
     // Loop through the supported extensions to find the file.


### PR DESCRIPTION
Based on https://github.com/GarageGames/Torque2D/issues/82

Con::expandPath adds functionality and checks before calling makeFullPathName and simplifies the code.
