### PR TITLE
ParticlePlayer Stop and Play functions Fixed

### DIFF
--- a/engine/source/2d/sceneobject/ParticlePlayer.cc
+++ b/engine/source/2d/sceneobject/ParticlePlayer.cc
@@ -401,14 +401,10 @@ void ParticlePlayer::integrateObject( const F32 totalTime, const F32 elapsedTime
     // Fetch the particle life-mode.
     const ParticleAsset::LifeMode lifeMode = pParticleAsset->getLifeMode();
 
-    // Finish if the particle player is in "infinite" mode.
-    if ( lifeMode == ParticleAsset::INFINITE )
-        return;
-
     // Are we waiting for particles and there are non left?
     if ( mWaitingForParticles )
     {
-        // Yes, so are there any particles left?
+		// Yes, so are there any particles left?
         if ( activeParticleCount == 0 )
         {
             // No, so stop the player immediately.
@@ -417,6 +413,10 @@ void ParticlePlayer::integrateObject( const F32 totalTime, const F32 elapsedTime
 
         return;
     }
+
+	// Finish if the particle player is in "infinite" mode.
+    if ( lifeMode == ParticleAsset::INFINITE )
+        return;
 
     // Fetch the particle lifetime.
     const F32 lifetime = pParticleAsset->getLifetime();
@@ -793,7 +793,7 @@ bool ParticlePlayer::play( const bool resetParticles )
     {
         // Fetch the emitter node.
         EmitterNode* pEmitterNode = *emitterItr;
-
+		pEmitterNode->setPaused(false);
         // Reset the time since last generation.
         pEmitterNode->setTimeSinceLastGeneration( 0.0f );
     }


### PR DESCRIPTION
When LifeMode was set to INFINITE (default), the check for Waitforparticles was skipped.
- Fix : moved check for LifeMode after the check for WaitforParticles

When calling ParticlePlayer.stop(), subsequent calls to ParticlePlayer.play() would not work.
- Fix : On ParticlePlayer.stop, particle emitters were paused individually, never unpaused later.

https://github.com/GarageGames/Torque2D/issues/64
