### PR TITLE
Fix ImageFont AABB size with left or right text alignment

### DIFF
--- a/engine/source/2d/sceneobject/ImageFont.cc
+++ b/engine/source/2d/sceneobject/ImageFont.cc
@@ -366,14 +366,14 @@ void ImageFont::calculateSpatials( void )
         case ALIGN_LEFT:
             {
                 // Size is twice the padded text width as we're aligning to the left from the position expanding rightwards.
-                setSize( totalPaddedTextSize * 2.0f );
+                setSize( totalPaddedTextSize.x * 2.0f, totalPaddedTextSize.y );
             }
             break;
 
         case ALIGN_RIGHT:
             {
                 // Size is twice the padded text width as we're aligning to the right from the position expanding leftwards.
-                setSize( totalPaddedTextSize * 2.0f );
+                setSize( totalPaddedTextSize.x * 2.0f, totalPaddedTextSize.y );
             }
             break;
 


### PR DESCRIPTION
left or right text alignment should only pad the width, previously both width and height were being doubled.
