### PR TITLE
FontSize and FontPadding TAML export

### DIFF
--- a/engine/source/2d/sceneobject/ImageFont.cc
+++ b/engine/source/2d/sceneobject/ImageFont.cc
@@ -328,7 +328,7 @@ void ImageFont::setFontSize( const Vector2& size )
 
 //-----------------------------------------------------------------------------
 
-void ImageFont::setFontPadding( const U32 padding )
+void ImageFont::setFontPadding( const F32 padding )
 {
     mFontPadding = padding;
     calculateSpatials();
@@ -349,7 +349,7 @@ void ImageFont::calculateSpatials( void )
     }
 
     // Calculate total font padding.
-    const U32 totalFontPadding = (renderCharacters * mFontPadding) - mFontPadding;
+    const F32 totalFontPadding = (renderCharacters * mFontPadding) - mFontPadding;
 
     // Calculate total character size.
     const Vector2 totalFontSize( renderCharacters * mFontSize.x, mFontSize.y );

--- a/engine/source/2d/sceneobject/ImageFont.h
+++ b/engine/source/2d/sceneobject/ImageFont.h
@@ -75,7 +75,7 @@ private:
 private:
     AssetPtr<ImageAsset>    mImageAsset;
     StringBuffer            mText;
-    U32                     mFontPadding;
+    F32                     mFontPadding;
     Vector2                 mFontSize;
     TextAlignment           mTextAlignment;
 
@@ -106,8 +106,8 @@ public:
     inline TextAlignment getTextAlignment( void ) const                     { return mTextAlignment; }
     void setFontSize( const Vector2& size );
     inline Vector2 getFontSize( void ) const                                { return mFontSize; }
-    void setFontPadding( const U32 padding );
-    inline U32 getFontPadding( void ) const                                 { return mFontPadding; }
+    void setFontPadding( const F32 padding );
+    inline F32 getFontPadding( void ) const                                 { return mFontPadding; }
 
     static TextAlignment getTextAlignmentEnum(const char* label);
     static const char* getTextAlignmentDescription(const TextAlignment alignment);
@@ -125,8 +125,8 @@ protected:
     static bool setTextAlignment( void* obj, const char* data );
     static bool writeTextAlignment( void* obj, StringTableEntry pFieldName ){return static_cast<ImageFont*>(obj)->getTextAlignment() != ImageFont::ALIGN_CENTER; }
     static bool setFontSize( void* obj, const char* data )                  { static_cast<ImageFont*>( obj )->setFontSize( Utility::mGetStringElementVector(data) ); return false; }
-    static bool writeFontSize( void* obj, StringTableEntry pFieldName )     { return static_cast<ImageFont*>(obj)->getFontSize().isEqual(Vector2::getOne()); }
-    static bool setFontPadding( void* obj, const char* data )               { static_cast<ImageFont*>( obj )->setFontPadding( dAtoi(data) ); return false; }
+	static bool writeFontSize( void* obj, StringTableEntry pFieldName )     { return static_cast<ImageFont*>(obj)->getFontSize().notEqual(Vector2::getOne()); }	
+    static bool setFontPadding( void* obj, const char* data )               { static_cast<ImageFont*>( obj )->setFontPadding( dAtof(data) ); return false; }
     static bool writeFontPadding( void* obj, StringTableEntry pFieldName )  { return static_cast<ImageFont*>(obj)->getFontPadding() != 0; }
 };
 

--- a/engine/source/2d/sceneobject/ImageFont_ScriptBinding.h
+++ b/engine/source/2d/sceneobject/ImageFont_ScriptBinding.h
@@ -124,13 +124,13 @@ ConsoleMethod(ImageFont, setFontPadding, void, 3, 3,    "(padding) - Set the fon
                                                         "@return No return value.")
 {
    // Set character padding.
-   object->setFontPadding( dAtoi(argv[2]) );
+   object->setFontPadding( dAtof(argv[2]) );
 
 }
 
 //-----------------------------------------------------------------------------
 
-ConsoleMethod(ImageFont, getFontPadding, S32, 2, 2,     "() - Gets the font padding.\n"
+ConsoleMethod(ImageFont, getFontPadding, F32, 2, 2,     "() - Gets the font padding.\n"
                                                         "@return The font padding.")
 {
     return object->getFontPadding();


### PR DESCRIPTION
FontSize is now written out to TAML correctly.
FontPadding converted from U32 to F32, making it write out to TAML correctly as well.
