### PR TITLE
SimXMLDocument GetData() will crash if it encounters an empty XML elemen...

### DIFF
--- a/engine/source/persistence/SimXMLDocument.cpp
+++ b/engine/source/persistence/SimXMLDocument.cpp
@@ -1095,7 +1095,12 @@ const char* SimXMLDocument::getData()
    if(!pNode)
       return "";
 
-   TiXmlText* text = pNode->FirstChild()->ToText();
+   TiXmlNode * firstChild =  pNode->FirstChild();
+
+   if(!firstChild)
+	   return "";
+
+   TiXmlText* text = firstChild->ToText();
    if( !text )
       return "";
 


### PR DESCRIPTION
...t

From this closed pull request (wrong branch, sorry if i did it wrong again :confused: )
https://github.com/GarageGames/Torque2D/pull/112

This bug was submitted 3 years ago but has never been fixed.
http://www.garagegames.com/community/forums/viewthread/120911

In some cases,  FirstChild() can be null, giving a crash when we call ToText().

Here's a simple example to reproduce the crash

``` c++
//Parse the xml => Go to "tag" element and get data
    %xml = "<xml><tag/></xml>";
    %parser = new SimXMLDocument();
    %parser.parse(%xml);
    %parser.pushChildElement(0);
    %parser.pushChildElement(0);
    echo("Current element is:" SPC %parser.elementValue()); //To check that the current tag is "tag"
    echo("Data:" SPC  %parser.getData());
```
