### PR TITLE
Open al shutdown

### DIFF
--- a/engine/source/platformWin32/winWindow.cc
+++ b/engine/source/platformWin32/winWindow.cc
@@ -1494,9 +1494,9 @@ void Platform::init()
 //--------------------------------------
 void Platform::shutdown()
 {
-   sgQueueEvents = false;
-
+   sgQueueEvents = false;   
    setMouseLock( false );
+   Audio::OpenALShutdown();
    Video::destroy();
    Input::destroy();
    WinConsole::destroy();


### PR DESCRIPTION
OpenALShutdown is now called when the game exits
