### PR TITLE
Fix for input bug in OSX

### DIFF
--- a/engine/source/platformOSX/osxTorqueView.mm
+++ b/engine/source/platformOSX/osxTorqueView.mm
@@ -236,7 +236,10 @@
     torqueEvent.modifier = modifiers;
     torqueEvent.ascii = 0;
     torqueEvent.action = action;
-    torqueEvent.fValue = 1.0;
+    if (action == SI_BREAK)
+        torqueEvent.fValue = 0.0;
+    else
+        torqueEvent.fValue = 1.0;
     
     // Post the input event
     Game->postEvent(torqueEvent);


### PR DESCRIPTION
This fixes a bug with input on OSX where if you bind a command it will now send the correct value to TorqueScript.

This fix was originally submitted in pull request #91
Credit for this fix to timmgt
