### PR TITLE
Bugfix/namespace clone

### DIFF
--- a/engine/source/sim/simObject.cc
+++ b/engine/source/sim/simObject.cc
@@ -1128,7 +1128,7 @@ void SimObject::copyTo(SimObject* object)
 {
    object->mClassName = mClassName;
    object->mSuperClassName = mSuperClassName;
-
+   object->mNameSpace = NULL;
    object->linkNamespaces();
 }
 


### PR DESCRIPTION
Fix issue #76.
Cloned objects failed to have namespace pointer initialized to NULL, causing the reference counter to fail to increment properly.
