### PR TITLE
Fixed some compiler warnings in Xcode

### DIFF
--- a/engine/compilers/Xcode/Torque2D.xcodeproj/project.pbxproj
+++ b/engine/compilers/Xcode/Torque2D.xcodeproj/project.pbxproj
@@ -3228,7 +3228,7 @@
 		869FF8AF1651518C002FE082 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0460;
+				LastUpgradeCheck = 0500;
 				ORGANIZATIONNAME = "Michael Perry";
 			};
 			buildConfigurationList = 869FF8B21651518C002FE082 /* Build configuration list for PBXProject "Torque2D" */;

--- a/engine/source/2d/controllers/BuoyancyController.cc
+++ b/engine/source/2d/controllers/BuoyancyController.cc
@@ -75,7 +75,8 @@ void BuoyancyController::copyTo(SimObject* object)
     Parent::copyTo(object);
 
     // Cast to controller.
-    BuoyancyController* pController = static_cast<BuoyancyController*>(object);
+    BuoyancyController* pController;
+    pController = static_cast<BuoyancyController*>(object);
 
     // Sanity!
     AssertFatal(pController != NULL, "BuoyancyController::copyTo() - Object is not the correct type.");

--- a/engine/source/2d/scene/Scene.cc
+++ b/engine/source/2d/scene/Scene.cc
@@ -138,7 +138,7 @@ static StringTableEntry jointMotorMaxTorqueName           = jointRevoluteMotorMa
 static StringTableEntry jointMotorCorrectionFactorName    = StringTable->insert( "CorrectionFactor" );
 
 // Controller custom node names.
-static StringTableEntry controllerCustomNodeName	      = StringTable->insert( "Controllers" );
+static StringTableEntry controllerCustomNodeName          = StringTable->insert( "Controllers" );
 
 // Asset preload custom node names.
 static StringTableEntry assetPreloadNodeName              = StringTable->insert( "AssetPreloads" );
@@ -1617,7 +1617,8 @@ S32 Scene::createJoint( b2JointDef* pJointDef )
     const S32 jointId = mJointMasterId++;
 
     // Insert joint.
-    typeJointHash::iterator itr = mJoints.insert( jointId, pJoint );
+    typeJointHash::iterator itr;
+    itr = mJoints.insert( jointId, pJoint );
 
     // Sanity!
     AssertFatal( itr != mJoints.end(), "Joint already in hash table." );
@@ -2183,7 +2184,7 @@ F32 Scene::getRevoluteJointAngle( const U32 jointId )
 
 //-----------------------------------------------------------------------------
 
-F32	Scene::getRevoluteJointSpeed( const U32 jointId )
+F32 Scene::getRevoluteJointSpeed( const U32 jointId )
 {
     // Fetch joint.
     b2Joint* pJoint = findJoint( jointId );

--- a/engine/source/graphics/TextureManager.cc
+++ b/engine/source/graphics/TextureManager.cc
@@ -229,7 +229,8 @@ void TextureManager::resurrectManager( void )
                     AssertISV(pBitmap != NULL, "Error resurrecting the texture cache.\n""Possible cause: a bitmap was deleted during the course of gameplay.");
 
                     // Register texture.
-                    TextureObject* pTextureObject = registerTexture(probe->mTextureKey, pBitmap, probe->mHandleType, probe->mClamp);
+                    TextureObject* pTextureObject;
+                    pTextureObject = registerTexture(probe->mTextureKey, pBitmap, probe->mHandleType, probe->mClamp);
 
                     // Sanity!
                     AssertFatal(pTextureObject == probe, "A new texture was returned during resurrection.");
@@ -415,7 +416,7 @@ void TextureManager::getSourceDestByteFormat(GBitmap *pBitmap, U32 *sourceFormat
     *destFormat = *sourceFormat;
     *texelSize = byteSize;
     return;
-#else	
+#else   
     switch(pBitmap->getFormat()) 
     {
     case GBitmap::Intensity:
@@ -681,7 +682,8 @@ void TextureManager::refresh( const char *textureName )
         return;
 
     // Register texture.
-    TextureObject* pNewTextureObject = registerTexture(pTextureObject->mTextureKey, pBitmap, pTextureObject->mHandleType, pTextureObject->mClamp);
+    TextureObject* pNewTextureObject;
+    pNewTextureObject = registerTexture(pTextureObject->mTextureKey, pBitmap, pTextureObject->mHandleType, pTextureObject->mClamp);
 
     // Sanity!
     AssertFatal(pNewTextureObject == pTextureObject, "A new texture was returned during refresh.");

--- a/engine/source/gui/containers/guiGridCtrl.cc
+++ b/engine/source/gui/containers/guiGridCtrl.cc
@@ -1,3 +1,25 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) 2013 GarageGames, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//-----------------------------------------------------------------------------
+
 #include "gui/containers/guiGridCtrl.h"
 
 //------------------------------------------------------------------------------
@@ -242,7 +264,8 @@ void GuiGridControl::AdjustGrid(const Point2I& newExtent)
 void GuiGridControl::AdjustGridItems(S32 size, Vector<StringTableEntry>& strItems, Vector<S32>& items)
 {
 	Vector<GridItem> GridItems;
-	S32 bFoundStar = false;
+    S32 bFoundStar;
+	bFoundStar = false;
 	S32 IndexRemaining = -1;
 	S32 totalSize = 0;
 	S32 idx =0;

--- a/engine/source/io/zip/zipSubStream.cc
+++ b/engine/source/io/zip/zipSubStream.cc
@@ -428,7 +428,8 @@ bool ZipSubWStream::_write(const U32 numBytes, const void *pBuffer)
          m_pZipStream->avail_out = csm_bufferSize;
       }
 
-      S32 retVal = deflate(m_pZipStream, Z_NO_FLUSH);
+      S32 retVal;
+      retVal = deflate(m_pZipStream, Z_NO_FLUSH);
       AssertFatal(retVal !=  Z_BUF_ERROR, "ZipSubWStream::_write: invalid buffer");
    }
 

--- a/engine/source/platformOSX/osxGL.mm
+++ b/engine/source/platformOSX/osxGL.mm
@@ -135,7 +135,8 @@ CGLContextObj getContextForCapsCheck()
 // Find out which extensions are available for this renderer. 
 void getGLCapabilities()
 {
-    osxPlatState * platState = [osxPlatState sharedPlatState];
+    osxPlatState * platState;
+    platState = [osxPlatState sharedPlatState];
     
     AssertFatal([platState cgDisplay], "getGLCapabilities() was called before a monitor was chosen!");
     

--- a/engine/source/platformOSX/osxMutex.mm
+++ b/engine/source/platformOSX/osxMutex.mm
@@ -35,7 +35,7 @@ struct PlatformMutexData
 {
     pthread_mutex_t   mMutex;
     bool              locked;
-    U32         lockedByThread;
+    U32               lockedByThread;
 };
 
 //-----------------------------------------------------------------------------
@@ -66,7 +66,8 @@ Mutex::Mutex()
 Mutex::~Mutex()
 {
     // Destroy the system mutex.
-    const bool ok = pthread_mutex_destroy( &(mData->mMutex) );
+    bool ok;
+    ok = pthread_mutex_destroy( &(mData->mMutex) );
     
     // Sanity!
     AssertFatal(ok == 0, "~Mutex() failed: pthread_mutex_destroy() failed.");
@@ -83,7 +84,8 @@ bool Mutex::lock( bool block )
     if( block )
     {
         // Yes, so block until mutex can be locked.
-        const bool ok = pthread_mutex_lock( &(mData->mMutex) );
+        bool ok;
+        ok = pthread_mutex_lock( &(mData->mMutex) );
         
         // Sanity!
         AssertFatal( ok != EINVAL, "Mutex::lockMutex() failed: invalid mutex.");
@@ -119,7 +121,8 @@ bool Mutex::lock( bool block )
 void Mutex::unlock()
 {
     // Unlock the thread.
-    const bool ok = pthread_mutex_unlock( &(mData->mMutex) );
+    bool ok;
+    ok = pthread_mutex_unlock( &(mData->mMutex) );
     
     // Sanity!
     AssertFatal( ok == 0, "Mutex::unlockMutex() failed: pthread_mutex_unlock() failed.");


### PR DESCRIPTION
There are still a couple warnings that need to be squashed and I'm not sure how to fix:

Scene_ScriptBinding.h line 1988: Unsequenced modification and access to 'nextArg'

``` cpp
if ( worldGroundAnchorAElementCount == 1 && argc > 5 )
    {
        worldGroundAnchorA.Set( dAtof(argv[nextArg]), dAtof(argv[nextArg++]) );
        nextArg += 2;
    }
```

PBXCp Warning: skipping copy phase strip, binary code is signed: for libLeap.dylib
