### PR TITLE
Fix "Gui Object Namespace Issue" 

### DIFF
--- a/engine/source/sim/simObject.cc
+++ b/engine/source/sim/simObject.cc
@@ -1314,14 +1314,16 @@ void SimObject::unlinkNamespaces()
 
 void SimObject::setClassNamespace( const char *classNamespace )
 {
-   mClassName = StringTable->insert( classNamespace );
-   linkNamespaces();
+    mClassName = StringTable->insert( classNamespace );
+    if (mFlags.test(Added))
+        linkNamespaces();
 }
 
 void SimObject::setSuperClassNamespace( const char *superClassNamespace )
-{  
-   mSuperClassName = StringTable->insert( superClassNamespace );
-   linkNamespaces();
+{
+    mSuperClassName = StringTable->insert( superClassNamespace );
+    if (mFlags.test(Added))
+        linkNamespaces();
 }
 
 static S32 QSORT_CALLBACK compareFields(const void* a,const void* b)


### PR DESCRIPTION
outlined in http://www.garagegames.com/community/forums/viewthread/136187

The taml parser uses existing simobject functions that assume an added state when this is not the case.
