### PR TITLE
Fixed Crash when executing FileDialogs

### DIFF
--- a/engine/source/platform/nativeDialogs/fileDialog.cc
+++ b/engine/source/platform/nativeDialogs/fileDialog.cc
@@ -31,10 +31,11 @@ IMPLEMENT_CONOBJECT(OpenFolderDialog);
 //-----------------------------------------------------------------------------
 FileDialogData::FileDialogData()
 {
-    mDefaultPath = StringTable->insert("");
-    mFilters = StringTable->insert("");
-    mFile = StringTable->insert("");
-    mTitle = StringTable->insert("");
+    mDefaultPath = StringTable->EmptyString;
+    mDefaultFile = StringTable->EmptyString;
+    mFilters = StringTable->EmptyString;
+    mFile = StringTable->EmptyString;
+    mTitle = StringTable->EmptyString;
     mStyle = 0;
 
 	mDefaultPath = StringTable->insert(Con::getVariable("Tools::FileDialogs::LastFilePath"));

--- a/engine/source/platformWin32/nativeDialogs/win32FileDialog.cc
+++ b/engine/source/platformWin32/nativeDialogs/win32FileDialog.cc
@@ -237,10 +237,10 @@ bool FileDialog::Execute()
    UTF16 pszFilter[1024];
    UTF16 pszFileTitle[MAX_PATH];
    // Convert parameters to UTF16*'s
-   convertUTF8toUTF16((UTF8 *)mData.mDefaultFile, pszFile, sizeof(pszFile));
-   convertUTF8toUTF16((UTF8 *)mData.mDefaultPath, pszInitialDir, sizeof(pszInitialDir));
-   convertUTF8toUTF16((UTF8 *)mData.mTitle, pszTitle, sizeof(pszTitle));
-   convertUTF8toUTF16((UTF8 *)mData.mFilters, pszFilter, sizeof(pszFilter) );
+   if(mData.mDefaultFile != StringTable->EmptyString)    convertUTF8toUTF16((UTF8 *)mData.mDefaultFile, pszFile, sizeof(pszFile));
+   if(mData.mDefaultPath != StringTable->EmptyString)    convertUTF8toUTF16((UTF8 *)mData.mDefaultPath, pszInitialDir, sizeof(pszInitialDir));
+   if(mData.mTitle != StringTable->EmptyString)			 convertUTF8toUTF16((UTF8 *)mData.mTitle, pszTitle, sizeof(pszTitle));
+   if(mData.mFilters != StringTable->EmptyString)		 convertUTF8toUTF16((UTF8 *)mData.mFilters, pszFilter, sizeof(pszFilter) );
 #else
    // Not Unicode, All char*'s!
    char pszFile[MAX_PATH];


### PR DESCRIPTION
Code was trying to parse Strings even if they did not exist, which caused the engine to crash.
