### PR TITLE
Exposed method CompositeSprite::getSpriteLogicalPosition in TorqueScript

### DIFF
--- a/engine/source/2d/core/SpriteBatch.cc
+++ b/engine/source/2d/core/SpriteBatch.cc
@@ -604,6 +604,18 @@ Vector2 SpriteBatch::getSpriteLocalPosition( void )
 
 //------------------------------------------------------------------------------
 
+const SpriteBatchItem::LogicalPosition SpriteBatch::getSpriteLogicalPosition( void ) const
+{
+    // Finish if a sprite is not selected.
+    if ( !checkSpriteSelected() )
+        return NULL;
+    
+    // Get logical position.
+    return mSelectedSprite->getLogicalPosition();
+}
+
+//------------------------------------------------------------------------------
+
 void SpriteBatch::setSpriteAngle( const F32 localAngle )
 {
     // Finish if a sprite is not selected.

--- a/engine/source/2d/core/SpriteBatch.h
+++ b/engine/source/2d/core/SpriteBatch.h
@@ -135,6 +135,8 @@ public:
     void setSpriteLocalPosition( const Vector2& localPosition );
     Vector2 getSpriteLocalPosition( void );
 
+    const SpriteBatchItem::LogicalPosition getSpriteLogicalPosition( void ) const;
+
     void setSpriteAngle( const F32 localAngle );
     F32 getSpriteAngle( void ) const;
 

--- a/engine/source/2d/sceneobject/CompositeSprite_ScriptBinding.h
+++ b/engine/source/2d/sceneobject/CompositeSprite_ScriptBinding.h
@@ -513,6 +513,16 @@ ConsoleMethodWithDocs(CompositeSprite, getSpriteLocalPosition, ConsoleString, 2,
 
 //-----------------------------------------------------------------------------
 
+/*! Gets the sprite logical position.
+    @return The sprite logical position.
+*/
+ConsoleMethodWithDocs(CompositeSprite, getSpriteLogicalPosition, ConsoleString, 2, 2, ())
+{
+    return object->getSpriteLogicalPosition().getString();
+}
+
+//-----------------------------------------------------------------------------
+
 /*! Sets the sprites local angle.
     @param localAngle The sprite local angle.
     @return No return value.


### PR DESCRIPTION
I've tested this and it seems to work fine. I was just slightly unsure about the C++ code, as it was difficult to find a similar example in the source to base this addition on - so I've submitted this as a pull request for peer review.
