### PR TITLE
Bugfix: SkeletonObjects now respect scene layer depth settings.

### DIFF
--- a/engine/source/2d/sceneobject/SkeletonObject.cc
+++ b/engine/source/2d/sceneobject/SkeletonObject.cc
@@ -416,6 +416,8 @@ void SkeletonObject::updateComposition( const F32 time )
         spRegionAttachment_computeWorldVertices(regionAttachment, slot->skeleton->x, slot->skeleton->y, slot->bone, vertexPositions);
         
         SpriteBatchItem* pSprite = SpriteBatch::createSprite();
+
+        pSprite->setDepth(mSceneLayerDepth);
         
         pSprite->setSrcBlendFactor(mSrcBlendFactor);
         pSprite->setDstBlendFactor(mDstBlendFactor);


### PR DESCRIPTION
Thanks to Simon Love for highlighting this issue and providing a fix.
