### PR TITLE
Xinput thumbsticks fix

### DIFF
--- a/engine/source/platformWin32/winDirectInput.cc
+++ b/engine/source/platformWin32/winDirectInput.cc
@@ -786,8 +786,8 @@ void DInputManager::processXInput( void )
          if( mXInputDeadZoneOn )
          {
 			 //Verify each axis of each thumbstick and reset only if appropriate
-			 if(mXInputStateNew[i].state.Gamepad.sThumbLX < XINPUT_DEADZONE && mXInputStateNew[i].state.Gamepad.sThumbLX > -XINPUT_DEADZONE) 
-				 mXInputStateNew[i].state.Gamepad.sThumbLX = 0;
+             if(mXInputStateNew[i].state.Gamepad.sThumbLX < XINPUT_DEADZONE && mXInputStateNew[i].state.Gamepad.sThumbLX > -XINPUT_DEADZONE) 
+               mXInputStateNew[i].state.Gamepad.sThumbLX = 0;
 
              if(mXInputStateNew[i].state.Gamepad.sThumbLY < XINPUT_DEADZONE && mXInputStateNew[i].state.Gamepad.sThumbLY > -XINPUT_DEADZONE)
                mXInputStateNew[i].state.Gamepad.sThumbLY = 0;


### PR DESCRIPTION
https://github.com/GarageGames/Torque2D/issues/186

Each axis of each thumbstick is verified and set to 0 if appropriate.
