### PR TITLE
Xinput Thumbstick Deadzone fix

### DIFF
--- a/engine/source/platformWin32/winDirectInput.cc
+++ b/engine/source/platformWin32/winDirectInput.cc
@@ -797,7 +797,6 @@ void DInputManager::processXInput( void )
 
             if(mXInputStateNew[i].state.Gamepad.sThumbRY < XINPUT_DEADZONE && mXInputStateNew[i].state.Gamepad.sThumbRY > -XINPUT_DEADZONE)
             mXInputStateNew[i].state.Gamepad.sThumbRY = 0;
-            }
          }
 
          // this controller was connected or disconnected


### PR DESCRIPTION
https://github.com/GarageGames/Torque2D/issues/186

The Deadzone of each thumbstick is verified independently and reset if needed.
