### PR TITLE
Fix compile cast warnings present in VS

### DIFF
--- a/engine/source/2d/sceneobject/ImageFont_ScriptBinding.h
+++ b/engine/source/2d/sceneobject/ImageFont_ScriptBinding.h
@@ -144,7 +144,7 @@ ConsoleMethodWithDocs(ImageFont, getFontSize, ConsoleString, 2, 2, ())
 ConsoleMethodWithDocs(ImageFont, setFontPadding, ConsoleVoid, 3, 3, (padding))
 {
    // Set character padding.
-   object->setFontPadding( dAtoi(argv[2]) );
+   object->setFontPadding( (const F32) dAtoi(argv[2]) );
 
 }
 
@@ -155,7 +155,7 @@ ConsoleMethodWithDocs(ImageFont, setFontPadding, ConsoleVoid, 3, 3, (padding))
 */
 ConsoleMethodWithDocs(ImageFont, getFontPadding, ConsoleInt, 2, 2, ())
 {
-    return object->getFontPadding();
+    return (S32) object->getFontPadding();
 }
 
 ConsoleMethodGroupEndWithDocs(ImageFont)

--- a/engine/source/platformWin32/winDirectInput.cc
+++ b/engine/source/platformWin32/winDirectInput.cc
@@ -732,7 +732,7 @@ inline void DInputManager::fireXInputButtonEvent( int controllerID, bool forceFi
 	  Con::printf("%s", objName);
 	  */
 
-      buildXInputEvent( controllerID, XI_BUTTON, objInst, action, ( action == XI_MAKE ? 1 : 0 ) );
+      buildXInputEvent( controllerID, XI_BUTTON, objInst, action, (float) ( action == XI_MAKE ? 1 : 0 ) );
    }
 }
 


### PR DESCRIPTION
The wiki asserts that there are no compile time warnings, but there are a few present in VS builds. This patch fixes those.
