### PR TITLE
Fix type mismatch (C4244) in VS builds

### DIFF
--- a/engine/source/platformWin32/winDirectInput.cc
+++ b/engine/source/platformWin32/winDirectInput.cc
@@ -732,7 +732,7 @@ inline void DInputManager::fireXInputButtonEvent( int controllerID, bool forceFi
 	  Con::printf("%s", objName);
 	  */
 
-      buildXInputEvent( controllerID, XI_BUTTON, objInst, action, ( action == XI_MAKE ? 1 : 0 ) );
+      buildXInputEvent( controllerID, XI_BUTTON, objInst, action, ( action == XI_MAKE ? 1.0f : 0.0f ) );
    }
 }
 


### PR DESCRIPTION
Does not appear to me to be fixed in other pull requests. Pardon the multiple commits, I also originally tried to fix other C4244s but CapnLove fixes most of them with 100% fewer C casts in pull request #191.
