### PR TITLE
Initialize mXInputLib to NULL. 

### DIFF
--- a/engine/source/platformWin32/winDirectInput.cc
+++ b/engine/source/platformWin32/winDirectInput.cc
@@ -49,6 +49,7 @@ DInputManager::DInputManager()
    mDInputInterface  = NULL;
    mKeyboardActive   = mMouseActive = mJoystickActive = false;
    mXInputActive = true;
+   mXInputLib = NULL;
 
    for(S32 i=0; i<4; i++)
 	   mLastDisconnectTime[i] = -1;


### PR DESCRIPTION
This fixes a 'BADFOOD' pointer issue in Visual Studio.

As described in https://github.com/GarageGames/Torque2D/issues/197
