### PR TITLE
Set currentdirectory to executable path

### DIFF
--- a/engine/source/game/defaultGame.cc
+++ b/engine/source/game/defaultGame.cc
@@ -247,6 +247,7 @@ bool initializeGame(int argc, const char **argv)
         argc -= 2;
     }
 
+    Platform::setCurrentDirectory(Platform::getExecutablePath());
     // Scan executable location and all sub-directories.
     ResourceManager->setWriteablePath(Platform::getCurrentDirectory());
     ResourceManager->addPath( Platform::getCurrentDirectory() );


### PR DESCRIPTION
As described in https://github.com/GarageGames/Torque2D/issues/199
This is just a possible solution, I'm not saying it's the correct one just a suggestion. I can't see any case where the executable path shouldn't be current directory during startup.
