### PR TITLE
BuoyancyController Area Read fix

### DIFF
--- a/engine/source/2d/core/Utility.cc
+++ b/engine/source/2d/core/Utility.cc
@@ -41,7 +41,7 @@ ConsoleGetType( Typeb2AABB )
 
     // Format AABB.
     char* pBuffer = Con::getReturnBuffer(64);
-    dSprintf(pBuffer, 64, "%.5g %.5g", pAABB->lowerBound.x, pAABB->lowerBound.y, pAABB->upperBound.x, pAABB->upperBound.y );
+    dSprintf(pBuffer, 64, "%.5g %.5g %.5g %.5g", pAABB->lowerBound.x, pAABB->lowerBound.y, pAABB->upperBound.x, pAABB->upperBound.y );
     return pBuffer;
 }
 


### PR DESCRIPTION
When reading FluidArea from an existing Buoyancy Controller object, the engine now reads in 4 parameters, to create a coherent AABB. (Used to read only the first 2 parameters)

As discussed here
http://www.garagegames.com/community/forums/viewthread/137580
