### PR TITLE
Pfx tamlreadfix

### DIFF
--- a/engine/source/2d/assets/ParticleAssetField.cc
+++ b/engine/source/2d/assets/ParticleAssetField.cc
@@ -670,6 +670,13 @@ void ParticleAssetField::onTamlCustomRead( const TamlCustomNode* pCustomNode )
         keys.push_back( key );
     }
 
+	if(!keys.size())
+	{
+        DataKey key;
+		key.mTime = getMinTime();
+		key.mValue = getDefaultValue();
+        keys.push_back( key );
+	}
     // Set the value bounds.
     setValueBounds( maxTime, minValue, maxValue, defaultValue );
 


### PR DESCRIPTION
Fixes issue #203 => https://github.com/GarageGames/Torque2D/issues/203

If no keys have been read from file, set a Data Key to default value for the currently selected field.
Tested.
