### PR TITLE
Added getJoystickCount function for the Windows platform

### DIFF
--- a/engine/source/platformWin32/winDInputDevice.cc
+++ b/engine/source/platformWin32/winDInputDevice.cc
@@ -1482,5 +1482,7 @@ bool DInputDevice::joystickDetected()
    return( smJoystickCount > 0  );
 }
 
-
-
+U8 DInputDevice::getJoystickCount()
+{  
+   return(smJoystickCount);
+}

--- a/engine/source/platformWin32/winDInputDevice.h
+++ b/engine/source/platformWin32/winDInputDevice.h
@@ -135,7 +135,7 @@ class DInputDevice : public InputDevice
       // Console interface functions:
       const char* getJoystickAxesString();
       static bool joystickDetected();
-      //
+      static U8 getJoystickCount();
 
       bool process();
 };

--- a/engine/source/platformWin32/winInput_ScriptBinding.h
+++ b/engine/source/platformWin32/winInput_ScriptBinding.h
@@ -55,4 +55,14 @@ ConsoleFunctionWithDocs( getJoystickAxes, ConsoleString, 2, 2, ( instance ))
     return( "" );
 }
 
+/*! Returns the total number of joysticks connected, both XInput and other.
+    @return The number of joysticks connected.
+    @sa isJoystickDetected
+*/
+ConsoleFunctionWithDocs( getJoystickCount, ConsoleInt, 1, 1, ())
+{
+    argc; argv;
+    return( DInputDevice::getJoystickCount() );
+}
+
 /*! @} */ // end group WindowsPlatform


### PR DESCRIPTION
This replaces pull request #192 to fix the file encoding issue with winInput_ScriptBinding.h

Thanks to @capnlove for the original submission.
