### PR TITLE
Added initial value to mUsingNamedFrame, which caused crashes on copyTo

### DIFF
--- a/engine/source/2d/assets/ParticleAssetEmitter.cc
+++ b/engine/source/2d/assets/ParticleAssetEmitter.cc
@@ -205,6 +205,7 @@ ParticleAssetEmitter::ParticleAssetEmitter() :
     mAnimationAsset.registerRefreshNotify( this );
     
     mNamedImageFrame = "";
+    mUsingNamedFrame = false;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
#213 is now fixed with a simple value initialization.

Might be worth checking other instances, such as in ImageAsset.
