### PR TITLE
GuiSpriteCtrl overhaul

### DIFF
--- a/engine/source/2d/gui/guiSpriteCtrl.cc
+++ b/engine/source/2d/gui/guiSpriteCtrl.cc
@@ -45,11 +45,16 @@ IMPLEMENT_CONOBJECT(GuiSpriteCtrl);
 //-----------------------------------------------------------------------------
 
 GuiSpriteCtrl::GuiSpriteCtrl( void ) :
-    mImageAssetId( StringTable->EmptyString ),
-    mAnimationAssetId( StringTable->EmptyString )
+    mImageAssetId(StringTable->EmptyString),
+    mImageFrameId(0),
+    mNamedImageFrameId(StringTable-> EmptyString),
+    mAnimationAssetId(StringTable->EmptyString)
 {
-	// Set to self ticking.
-	mSelfTick = true;
+    // Set to self ticking.
+    mSelfTick = true;
+    
+    // Default to static provider.
+    mStaticProvider = true;
 }
 
 //-----------------------------------------------------------------------------
@@ -65,9 +70,37 @@ void GuiSpriteCtrl::initPersistFields()
     // Call parent.
     Parent::initPersistFields();
 
-    addProtectedField( "Image", TypeAssetId, Offset(mImageAssetId, GuiSpriteCtrl), &setImage, &getImage, &writeImage, "The image asset Id used for the image." );
-    addProtectedField( "Frame", TypeS32, Offset(mImageFrame, GuiSpriteCtrl), &setImageFrame, &defaultProtectedGetFn, &writeImageFrame, "The image frame used for the image." );
-    addProtectedField( "Animation", TypeAssetId, Offset(mAnimationAssetId, GuiSpriteCtrl), &setAnimation, &getAnimation, &writeAnimation, "The animation to use.");
+    addProtectedField("Image", TypeAssetId, Offset(mImageAssetId, GuiSpriteCtrl), &setImage, &defaultProtectedGetFn, &writeImage, "The image asset Id used for the image.");
+    addProtectedField("Frame", TypeS32, Offset(mImageFrameId, GuiSpriteCtrl), &setImageFrame, &defaultProtectedGetFn, &writeImageFrame, "The image frame used for the image.");
+    addProtectedField("NamedFrame", TypeString, Offset(mNamedImageFrameId, GuiSpriteCtrl), &setNamedImageFrame, &defaultProtectedGetFn, &writeNamedImageFrame, "The named image frame used for the image");
+    addProtectedField("Animation", TypeAssetId, Offset(mAnimationAssetId, GuiSpriteCtrl), &setAnimation, &defaultProtectedGetFn, &writeAnimation, "The animation to use.");
+}
+
+//------------------------------------------------------------------------------
+
+void GuiSpriteCtrl::copyTo(SimObject* object)
+{
+    // Call to parent.
+    Parent::copyTo(object);
+
+    // Cast to control.
+    GuiSpriteCtrl* pGuiSpriteCtrl = static_cast<GuiSpriteCtrl*>(object);
+
+    // Sanity!
+    AssertFatal(pGuiSpriteCtrl != NULL, "GuiSpriteCtrl::copyTo() - Object is not the correct type.");
+
+    // Copy asset fields.
+    if ( mImageAssetId != StringTable->EmptyString )
+    {
+        if ( !isUsingNamedImageFrame() )
+            pGuiSpriteCtrl->setImage( getImage(), getImageFrame() );
+        else
+            pGuiSpriteCtrl->setImage( getImage(), getNamedImageFrame() ); 
+    }
+    else if ( mAnimationAssetId != StringTable->EmptyString )
+    {
+        pGuiSpriteCtrl->setAnimation( getAnimation() );
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -81,13 +114,26 @@ bool GuiSpriteCtrl::onWake()
     // Are we in static mode?
     if ( mImageAssetId != StringTable->EmptyString )
     {
-        // Set image asset.
-		ImageFrameProvider::setImage( mImageAssetId );
+        if ( mNamedImageFrameId != StringTable->EmptyString)
+        {
+            // Set the image asset and named frame
+            ImageFrameProvider::setImage( mImageAssetId, mNamedImageFrameId );
+        }
+        else
+        {
+            // Set image asset and numerical frame.
+            ImageFrameProvider::setImage( mImageAssetId, mImageFrameId );
+        }
     }
     else if ( mAnimationAssetId != StringTable->EmptyString )
     {
         // Play animation asset.
-		ImageFrameProvider::setAnimation( mAnimationAssetId );
+        ImageFrameProvider::setAnimation( mAnimationAssetId );
+    }
+    else
+    {
+        // Not good, so warn.
+        Con::warnf("GuiSpriteCtrl::onWake() - No Image or Animation Asset defined.");
     }
 
     return true;
@@ -98,7 +144,7 @@ bool GuiSpriteCtrl::onWake()
 void GuiSpriteCtrl::onSleep()
 {
     // Clear assets.
-	ImageFrameProvider::clearAssets();
+    ImageFrameProvider::clearAssets();
 
     // Call parent.
     Parent::onSleep();
@@ -106,46 +152,130 @@ void GuiSpriteCtrl::onSleep()
 
 //-----------------------------------------------------------------------------
 
-bool GuiSpriteCtrl::setImage( const char* pImageAssetId )
+bool GuiSpriteCtrl::setImage( const char* pImageAssetId, const U32 frame )
 {
     // Sanity!
     AssertFatal( pImageAssetId != NULL, "Cannot use a NULL asset Id." );
 
     // Reset animation.
-    mAnimationAssetId = StringTable->EmptyString;
+    if ( mAnimationAssetId != StringTable->EmptyString )
+        mAnimationAssetId = StringTable->EmptyString;
 
     // Fetch the asset Id.
-    mImageAssetId = StringTable->insert(pImageAssetId);
+    if ( mImageAssetId != pImageAssetId )
+        mImageAssetId = StringTable->insert(pImageAssetId);
 
-    // Reset image frame.
-	mImageFrame = 0;
+    // Set the image frame if the image asset was set.
+    if ( mImageAssetId != StringTable->EmptyString )
+        setImageFrame(frame);
 
-	// Finish if not awake.
+    // Finish if not awake.
     if ( !isAwake() )
-		return true;
+        return true;
 
-	// Call parent.
-	if ( !ImageFrameProvider::setImage( pImageAssetId, mImageFrame ) )
-		return false;
+    // Call parent.
+    if ( !ImageFrameProvider::setImage(pImageAssetId, frame) )
+        return false;
 
     // Update control.
     setUpdate();
 
-	return true;
+    return true;
+}
+
+//-----------------------------------------------------------------------------
+
+bool GuiSpriteCtrl::setImage( const char* pImageAssetId, const char* pNamedFrame )
+{
+    // Sanity!
+    AssertFatal( pImageAssetId != NULL, "Cannot use a NULL asset Id." );
+
+    // Reset animation.
+    if ( mAnimationAssetId != StringTable->EmptyString )
+        mAnimationAssetId = StringTable->EmptyString;
+
+    // Fetch the asset Id.
+    if ( mImageAssetId != pImageAssetId )
+        mImageAssetId = StringTable->insert(pImageAssetId);
+
+    // Set the image frame if the image asset was set.
+    if ( mImageAssetId != StringTable->EmptyString )
+        setNamedImageFrame(pNamedFrame);
+
+    // Finish if not awake.
+    if ( !isAwake() )
+        return true;
+
+    // Call parent.
+    if ( !ImageFrameProvider::setImage(pImageAssetId, pNamedFrame) )
+        return false;
+
+    // Update control.
+    setUpdate();
+
+    return true;
 }
 
 //-----------------------------------------------------------------------------
 
 bool GuiSpriteCtrl::setImageFrame( const U32 frame )
 {
-	// Call parent.
-	if ( !ImageFrameProvider::setImageFrame( frame ) )
-		return false;
+    // Check Existing Image.
+    if ( mImageAssetId == StringTable->EmptyString )
+    {
+        // Warn.
+        Con::warnf("GuiSpriteCtrl::setImageFrame() - Cannot set frame without existing asset Id.");
+
+        // Return Here.
+        return false;
+    }
+
+    // Set frame.
+    mImageFrameId = frame;
+
+    // Finish if not awake.
+    if ( !isAwake() )
+        return true;
+
+    // Call parent.
+    if ( !ImageFrameProvider::setImageFrame(frame) )
+        return false;
 
     // Update control.
     setUpdate();
 
-	return true;
+    return true;
+}
+
+//-----------------------------------------------------------------------------
+
+bool GuiSpriteCtrl::setNamedImageFrame( const char* pNamedFrame )
+{
+    // Check Existing Image.
+    if ( mImageAssetId == StringTable->EmptyString )
+    {
+        // Warn.
+        Con::warnf("GuiSpriteCtrl::setNamedImageFrame() - Cannot set named frame without existing asset Id.");
+
+        // Return Here.
+        return false;
+    }
+
+    // Set named frame.
+    mNamedImageFrameId = StringTable->insert(pNamedFrame);
+
+    // Finish if not awake.
+    if ( !isAwake() )
+        return true;
+
+    // Call parent.
+    if ( !ImageFrameProvider::setNamedImageFrame(pNamedFrame) )
+        return false;
+
+    // Update control.
+    setUpdate();
+
+    return true;
 }
 
 //-----------------------------------------------------------------------------
@@ -155,29 +285,31 @@ bool GuiSpriteCtrl::setAnimation( const char* pAnimationAssetId )
     // Sanity!
     AssertFatal( pAnimationAssetId != NULL, "Cannot use a NULL asset Id." );
 
-    // Fetch the asset Id.
-    mAnimationAssetId = StringTable->insert(pAnimationAssetId);
-
     // Reset the image asset Id.
-    mImageAssetId = StringTable->EmptyString;
+    if ( mImageAssetId != StringTable->EmptyString )
+        mImageAssetId = StringTable->EmptyString;
+
+    // Fetch the asset Id.
+    if ( mAnimationAssetId != pAnimationAssetId )
+        mAnimationAssetId = StringTable->insert(pAnimationAssetId);
 
     // Finish if not awake.
     if ( !isAwake() )
-		return true;
+        return true;
 
     // Play animation asset if it's valid.
     if ( mAnimationAssetId != StringTable->EmptyString )
-		ImageFrameProvider::setAnimation( mAnimationAssetId );
+        ImageFrameProvider::setAnimation( mAnimationAssetId );
 
-	return true;
+    return true;
 }
 
 //-----------------------------------------------------------------------------
 
 void GuiSpriteCtrl::onRender( Point2I offset, const RectI &updateRect)
 {
-	// Call parent.
-	ImageFrameProvider::renderGui( *this, offset, updateRect );
+    // Call parent.
+    ImageFrameProvider::renderGui( *this, offset, updateRect );
 }
 
 //------------------------------------------------------------------------------
@@ -185,5 +317,5 @@ void GuiSpriteCtrl::onRender( Point2I offset, const RectI &updateRect)
 void GuiSpriteCtrl::onAnimationEnd( void )
 {
     // Clear assets.
-	ImageFrameProvider::clearAssets();
+    ImageFrameProvider::clearAssets();
 }

--- a/engine/source/2d/gui/guiSpriteCtrl.h
+++ b/engine/source/2d/gui/guiSpriteCtrl.h
@@ -36,6 +36,8 @@ private:
 
 protected:
     StringTableEntry                mImageAssetId;
+    U32                             mImageFrameId;
+    StringTableEntry                mNamedImageFrameId;
     StringTableEntry                mAnimationAssetId;
 
 public:
@@ -46,10 +48,19 @@ public:
     void onRender(Point2I offset, const RectI &updateRect);
     static void initPersistFields();
 
-	/// Static and Animated Assets.
-    virtual bool setImage( const char* pImageAssetId );
+    virtual void copyTo(SimObject* object);
+
+    // Static and Animated Assets.
+    inline bool setImage( const char* pImageAssetId ) { return setImage( pImageAssetId, mImageFrame ); }
+    virtual bool setImage( const char* pImageAssetId, const U32 frame );
+    virtual bool setImage( const char* pImageAssetId, const char* pNamedFrame );
+    inline StringTableEntry getImage( void ) const{ return mImageAssetId; }
     virtual bool setImageFrame( const U32 frame );
+    inline U32 getImageFrame( void ) const { return mImageFrameId; }
+    virtual bool setNamedImageFrame ( const char* namedFrame );
+    inline StringTableEntry getNamedImageFrame( void ) const { return mNamedImageFrameId; }
     virtual bool setAnimation( const char* pAnimationAssetId );
+    inline StringTableEntry getAnimation( void ) const { return mAnimationAssetId; }
 
     // Declare type.
     DECLARE_CONOBJECT(GuiSpriteCtrl);
@@ -59,13 +70,13 @@ protected:
 
 protected:
     static bool setImage(void* obj, const char* data) { static_cast<GuiSpriteCtrl*>(obj)->setImage( data ); return false; }
-    static const char* getImage(void* obj, const char* data) { return DYNAMIC_VOID_CAST_TO(GuiSpriteCtrl, ImageFrameProvider, obj)->getImage(); }
-    static bool writeImage( void* obj, StringTableEntry pFieldName ) { GuiSpriteCtrl* pCastObject = static_cast<GuiSpriteCtrl*>(obj); if ( !pCastObject->isStaticFrameProvider() ) return false; return pCastObject->mImageAssetId != StringTable->EmptyString; }
+    static bool writeImage(void* obj, StringTableEntry pFieldName) { GuiSpriteCtrl* pCastObject = static_cast<GuiSpriteCtrl*>(obj); if ( !pCastObject->isStaticFrameProvider() ) return false; return pCastObject->mImageAssetId != StringTable->EmptyString; }
     static bool setImageFrame(void* obj, const char* data) { static_cast<GuiSpriteCtrl*>(obj)->setImageFrame( dAtoi(data) ); return false; }
-    static bool writeImageFrame( void* obj, StringTableEntry pFieldName ) { GuiSpriteCtrl* pCastObject = static_cast<GuiSpriteCtrl*>(obj); return pCastObject->isStaticFrameProvider() && pCastObject->getImageFrame() > 0; }
+    static bool writeImageFrame(void* obj, StringTableEntry pFieldName) { GuiSpriteCtrl* pCastObject = static_cast<GuiSpriteCtrl*>(obj); if ( !pCastObject->isStaticFrameProvider() || pCastObject->isUsingNamedImageFrame() ) return false; return pCastObject->getImageFrame() > 0; }
+    static bool setNamedImageFrame(void* obj, const char* data) { static_cast<GuiSpriteCtrl*>(obj)->setNamedImageFrame(data); return false; }
+    static bool writeNamedImageFrame(void* obj, StringTableEntry pFieldName) { GuiSpriteCtrl* pCastObject = static_cast<GuiSpriteCtrl*>(obj); if ( !pCastObject->isStaticFrameProvider() || !pCastObject->isUsingNamedImageFrame() ) return false; return pCastObject->mNamedImageFrameId != StringTable->EmptyString; }
     static bool setAnimation(void* obj, const char* data) { static_cast<GuiSpriteCtrl*>(obj)->setAnimation(data); return false; };
-    static const char* getAnimation(void* obj, const char* data) { return DYNAMIC_VOID_CAST_TO(GuiSpriteCtrl, ImageFrameProvider, obj)->getAnimation(); }
-    static bool writeAnimation( void* obj, StringTableEntry pFieldName ) { GuiSpriteCtrl* pCastObject = static_cast<GuiSpriteCtrl*>(obj); if ( pCastObject->isStaticFrameProvider() ) return false; return pCastObject->mAnimationAssetId != StringTable->EmptyString; }
+    static bool writeAnimation(void* obj, StringTableEntry pFieldName) { GuiSpriteCtrl* pCastObject = static_cast<GuiSpriteCtrl*>(obj); if ( pCastObject->isStaticFrameProvider() ) return false; return pCastObject->mAnimationAssetId != StringTable->EmptyString; }
 };
 
 #endif //_GUISPRITECTRL_H_

--- a/engine/source/2d/gui/guiSpriteCtrl_ScriptBindings.h
+++ b/engine/source/2d/gui/guiSpriteCtrl_ScriptBindings.h
@@ -22,23 +22,55 @@
 
 ConsoleMethodGroupBeginWithDocs(GuiSpriteCtrl, GuiControl)
 
-/*! Gets whether the control is in static or dynamic (animated)mode.
-    @return Returns whether the control is in static or dynamic (animated)mode.
+/*! Gets whether the control is in static or dynamic (animated) mode.
+    @return Returns whether the control is in static or dynamic (animated) mode.
 */
-ConsoleMethodWithDocs( GuiSpriteCtrl, isStaticFrameProvider, ConsoleBool, 2, 2, ())
+ConsoleMethodWithDocs(GuiSpriteCtrl, isStaticFrameProvider, ConsoleBool, 2, 2, ())
 {
     return object->isStaticFrameProvider();
 }
 
+//------------------------------------------------------------------------------
+
+/*! Gets whether the control is using a numerical or named image frame.
+    @return Returns true when using a named frame, false when using a numerical index.
+*/
+ConsoleMethodWithDocs(GuiSpriteCtrl, isUsingNamedImageFrame, ConsoleBool, 2, 2, ())
+{
+    return object->isUsingNamedImageFrame();
+}
+
 //-----------------------------------------------------------------------------
 
-/*! Sets the image asset Id to use as the image.
-    @param imageAssetId The image asset Id to use as the image.
-    @return No return value.
+/*! Sets the control image and optionally the frame.
+    @param imageAssetId The image asset Id to display
+    @param frame The numerical or named frame of the image to display
+    @return Returns true on success.
 */
-ConsoleMethodWithDocs( GuiSpriteCtrl, setImage, ConsoleVoid, 3, 3, (imageAssetId))
+ConsoleMethodWithDocs(GuiSpriteCtrl, setImage, ConsoleBool, 3, 4, (imageAssetId, [frame]))
 {
-   object->setImage( argv[2] );
+    // Was a frame specified?
+    if (argc >= 4)
+    {
+        // Was it a number or a string?
+        if (!dIsalpha(*argv[3]))
+        {
+            // Fetch the numerical frame and set the image
+            const U32 frame = argc >= 4 ? dAtoi(argv[3]) : 0;
+            return object->setImage( argv[2], frame );
+        }
+        else
+        {
+            // Set the image and pass the named frame string
+            return object->setImage( argv[2], argv[3] );
+        }
+    }
+    else
+    {
+        // Frame was not specified, use default 0 and set the image
+        const U32 frame = 0;
+        return object->setImage( argv[2], frame );
+    }
 }
 
 //------------------------------------------------------------------------------
@@ -46,18 +78,18 @@ ConsoleMethodWithDocs( GuiSpriteCtrl, setImage, ConsoleVoid, 3, 3, (imageAssetId
 /*! Gets current image asset Id.
     @return (string imageAssetId) The image being displayed.
 */
-ConsoleMethodWithDocs( GuiSpriteCtrl, getImage, ConsoleString, 2, 2, ())
+ConsoleMethodWithDocs(GuiSpriteCtrl, getImage, ConsoleString, 2, 2, ())
 {
     // Are we in static mode?
     if ( !object->isStaticFrameProvider() )
     {
         // No, so warn.
-        Con::warnf( "GuiSpriteCtrl::getImage() - Method invalid, not in static mode." );
+        Con::warnf("GuiSpriteCtrl::getImage() - Method invalid, not in static mode.");
         return StringTable->EmptyString;
     }
 
     // Get image.
-    return DYNAMIC_VOID_CAST_TO(GuiSpriteCtrl, ImageFrameProvider, object)->getImage();
+    return object->getImage();
 }
 
 //-----------------------------------------------------------------------------
@@ -66,23 +98,39 @@ ConsoleMethodWithDocs( GuiSpriteCtrl, getImage, ConsoleString, 2, 2, ())
     @param imageFrame The image frame to use as the image.
     @return No return value.
 */
-ConsoleMethodWithDocs( GuiSpriteCtrl, setImageFrame, ConsoleVoid, 3, 3, (int imageFrame))
-{
-   object->setImageFrame( dAtoi(argv[2]) );
-}
-
-//------------------------------------------------------------------------------
-
-/*! Gets current image Frame.
-    @return (int frame) The frame currently being displayed.
-*/
-ConsoleMethodWithDocs( GuiSpriteCtrl, getImageFrame, ConsoleInt, 2, 2, ())
+ConsoleMethodWithDocs(GuiSpriteCtrl, setImageFrame, ConsoleBool, 3, 3, (int imageFrame))
 {
     // Are we in static mode?
     if ( !object->isStaticFrameProvider() )
     {
         // No, so warn.
-        Con::warnf( "GuiSpriteCtrl::getFrame() - Method invalid, not in static mode." );
+        Con::warnf("GuiSpriteCtrl::setImageFrame() - Method invalid, not in static mode.");
+        return false;
+    }
+
+    return object->setImageFrame( dAtoi(argv[2]) );
+}
+
+//------------------------------------------------------------------------------
+
+/*! Gets current numerical image frame.
+    @return (int frame) The numerical frame currently being displayed.
+*/
+ConsoleMethodWithDocs(GuiSpriteCtrl, getImageFrame, ConsoleInt, 2, 2, ())
+{
+    // Are we in static mode?
+    if ( !object->isStaticFrameProvider() )
+    {
+        // No, so warn.
+        Con::warnf("GuiSpriteCtrl::getImageFrame() - Method invalid, not in static mode.");
+        return -1;
+    }
+
+    // Are we using a named image frame?
+    if ( object->isUsingNamedImageFrame() )
+    {
+        // Yes, so warn.
+        Con::warnf("GuiSpriteCtrl::getImageFrame() - Method invalid, using a named image frame.");
         return -1;
     }
 
@@ -92,11 +140,57 @@ ConsoleMethodWithDocs( GuiSpriteCtrl, getImageFrame, ConsoleInt, 2, 2, ())
 
 //------------------------------------------------------------------------------
 
+/*! Sets the image frame using a named string.
+    @param frame The named frame to display
+    @return Returns true on success.
+*/
+ConsoleMethodWithDocs(GuiSpriteCtrl, setNamedImageFrame, ConsoleBool, 3, 3, (frame))
+{
+    // Are we in static mode?
+    if ( !object->isStaticFrameProvider() )
+    {
+        // No, so warn.
+        Con::warnf("GuiSpriteCtrl::setNamedImageFrame() - Method invalid, not in static mode.");
+        return false;
+    }
+
+    // Set the numerical frame
+    return object->setNamedImageFrame( argv[2] );
+}
+
+//------------------------------------------------------------------------------
+
+/*! Gets the current named image frame.
+    @return The current named image frame.
+*/
+ConsoleMethodWithDocs(GuiSpriteCtrl, getNamedImageFrame, ConsoleString, 2, 2, ())
+{
+    // Are we in static mode?
+    if ( !object->isStaticFrameProvider() )
+    {
+        // No, so warn.
+        Con::warnf("GuiSpriteCtrl::getNamedImageFrame() - Method invalid, not in static mode.");
+        return NULL;
+    }
+
+    // Are we using a named image frame?
+    if ( !object->isUsingNamedImageFrame() )
+    {
+        // No, so warn.
+        Con::warnf("GuiSpriteCtrl::getNamedImageFrame() - Method invalid, not using a named image frame.");
+        return NULL;
+    }
+
+    return object->getNamedImageFrame();
+}
+
+//------------------------------------------------------------------------------
+
 /*! Sets the animation asset Id to display.
     @param animationAssetId The animation asset Id to play
     @return No return value.
 */
-ConsoleMethodWithDocs( GuiSpriteCtrl, setAnimation, ConsoleVoid, 3, 3, (string animationAssetId))
+ConsoleMethodWithDocs(GuiSpriteCtrl, setAnimation, ConsoleVoid, 3, 3, (string animationAssetId))
 {
     // Set animation.
     object->setAnimation( argv[2] );
@@ -107,18 +201,228 @@ ConsoleMethodWithDocs( GuiSpriteCtrl, setAnimation, ConsoleVoid, 3, 3, (string a
 /*! Gets the current animation asset Id.
     @return (string ianimationAssetId) The animation being displayed.
 */
-ConsoleMethodWithDocs( GuiSpriteCtrl, getAnimation, ConsoleString, 2, 2, ())
+ConsoleMethodWithDocs(GuiSpriteCtrl, getAnimation, ConsoleString, 2, 2, ())
 {
     // Are we in static mode?
     if ( object->isStaticFrameProvider() )
     {
         // Yes, so warn.
-        Con::warnf( "GuiSpriteCtrl::getAnimation() - Method invalid, in static mode." );
+        Con::warnf("GuiSpriteCtrl::getAnimation() - Method invalid, in static mode.");
         return StringTable->EmptyString;
     }
 
     // Get animation.
-    return DYNAMIC_VOID_CAST_TO(GuiSpriteCtrl, ImageFrameProvider, object)->getAnimation();
+    return object->getAnimation();
+}
+
+//-----------------------------------------------------------------------------
+
+/*! Pause the current animation
+    @param enable If true, pause the animation. If false, continue animating
+*/
+ConsoleMethodWithDocs(GuiSpriteCtrl, pauseAnimation, ConsoleVoid, 3, 3, (bool enable))
+{
+    // Are we in static mode?
+    if ( object->isStaticFrameProvider() )
+    {
+        // Yes, so warn.
+        Con::warnf("GuiSpriteCtrl::pauseAnimation() - Method invalid, not in dynamic (animated) mode.");
+        return;
+    }
+
+    return static_cast<ImageFrameProvider*>(object)->pauseAnimation(dAtob(argv[2]));
+}
+
+//-----------------------------------------------------------------------------
+
+/*! Stop the current animation
+    @return No return value.
+*/
+ConsoleMethodWithDocs(GuiSpriteCtrl, stopAnimation, ConsoleVoid, 2, 2, ())
+{
+    // Are we in static mode?
+    if ( object->isStaticFrameProvider() )
+    {
+        // Yes, so warn.
+        Con::warnf("GuiSpriteCtrl::stopAnimation() - Method invalid, not in dynamic (animated) mode.");
+        return;
+    }
+
+    object->stopAnimation();
+}
+
+//-----------------------------------------------------------------------------
+
+/*! Sets the current animation frame. IMPORTANT: this is not the image frame number used in the animation!
+    @param frame Which frame of the animation to display
+    @return No return value.
+*/
+ConsoleMethodWithDocs(GuiSpriteCtrl, setAnimationFrame, ConsoleVoid, 3, 3, (int frame))
+{
+    // Are we in static mode?
+    if ( object->isStaticFrameProvider() )
+    {
+        // Yes, so warn.
+        Con::warnf("GuiSpriteCtrl::setAnimationFrame() - Method invalid, not in dynamic (animated) mode.");
+        return;
+    }
+
+    // Set Animation Frame
+    object->setAnimationFrame( dAtoi(argv[2]) );
+}
+
+//-----------------------------------------------------------------------------
+
+/*! Gets current frame index used in the animation. IMPORTANT: this is not the image frame number!
+    @return The current numerical animation frame
+*/
+ConsoleMethodWithDocs(GuiSpriteCtrl, getAnimationFrame, ConsoleInt, 2, 2, ())
+{
+    // Are we in static mode?
+    if ( object->isStaticFrameProvider() )
+    {
+        // Yes, so warn.
+        Con::warnf("GuiSpriteCtrl::getAnimationFrame() - Method invalid, not in dynamic (animated) mode.");
+        return -1;
+    }
+
+    // Get Animation Frame.
+    return object->getAnimationFrame();
+}
+
+//-----------------------------------------------------------------------------
+
+/*! Gets current numerical image frame used in the animation.
+    @return The current numerical animation frame
+*/
+ConsoleMethodWithDocs(GuiSpriteCtrl, getAnimationImageFrame, ConsoleInt, 2, 2, ())
+{
+    // Are we in static mode?
+    if ( object->isStaticFrameProvider() )
+    {
+        // Yes, so warn.
+        Con::warnf("GuiSpriteCtrl::getAnimationImageFrame() - Method invalid, not in dynamic (animated) mode.");
+        return -1;
+    }
+
+    // Get the current animation asset
+    const AnimationAsset* asset = object->getCurrentAnimation();
+    
+    // Are we using named animation frames?
+    if (asset->getNamedCellsMode())
+    {
+        // Yes, so warn.
+        Con::warnf("GuiSpriteCtrl::getAnimationImageFrame() - Method invalid, animation is in named cells mode.");
+        return -1;
+    }
+
+    // Get Image Frame.
+    return object->getCurrentAnimationFrame();
+}
+
+//-----------------------------------------------------------------------------
+
+/*! Gets current named image frame used in the animation.
+    @return The current named animation frame
+*/
+ConsoleMethodWithDocs(GuiSpriteCtrl, getAnimationNamedImageFrame, ConsoleString, 2, 2, ())
+{
+    // Are we in static mode?
+    if ( object->isStaticFrameProvider() )
+    {
+        // Yes, so warn.
+        Con::warnf("GuiSpriteCtrl::getAnimationNamedImageFrame() - Method invalid, not in dynamic (animated) mode.");
+        return NULL;
+    }
+    
+    // Get the current animation asset
+    const AnimationAsset* asset = object->getCurrentAnimation();
+
+    // Are we using named animation frames?
+    if (!asset->getNamedCellsMode())
+    {
+        // No, so warn.
+        Con::warnf("GuiSpriteCtrl::getAnimationNamedImageFrame() - Method invalid, animation not in named cells mode.");
+        return NULL;
+    }
+
+    // Get Image Frame.
+    return object->getCurrentNamedAnimationFrame();
+}
+
+//-----------------------------------------------------------------------------
+
+/*! Gets current animation time.
+    @return (float time) The current animation time
+*/
+ConsoleMethodWithDocs(GuiSpriteCtrl, getAnimationTime, ConsoleFloat, 2, 2, ())
+{
+    // Are we in static mode?
+    if ( object->isStaticFrameProvider() )
+    {
+        // Yes, so warn.
+        Con::warnf("GuiSpriteCtrl::getAnimationTime() - Method invalid, not in dynamic (animated) mode.");
+        return 0.0f;
+    }
+
+
+    // Get Animation Time.
+    return object->getCurrentAnimationTime();
+}
+
+//-----------------------------------------------------------------------------
+
+/*! Checks animation status.
+    @return (bool finished) Whether or not the animation is finished
+*/
+ConsoleMethodWithDocs(GuiSpriteCtrl, getIsAnimationFinished, ConsoleBool, 2, 2, ())
+{
+    // Are we in static mode?
+    if ( object->isStaticFrameProvider() )
+    {
+        // Yes, so warn.
+        Con::warnf("GuiSpriteCtrl::getIsAnimationFinished() - Method invalid, not in dynamic (animated) mode.");
+        return true;
+    }
+
+    // Return Animation Finished Status.
+    return object->isAnimationFinished();
+}
+
+//-----------------------------------------------------------------------------
+
+/*! Change the rate of animation.
+    @param timeScale Value which will scale the frame animation speed. 1 by default.
+*/
+ConsoleMethodWithDocs(GuiSpriteCtrl, setAnimationTimeScale, ConsoleVoid, 3, 3, (float timeScale))
+{
+    // Are we in static mode?
+    if ( object->isStaticFrameProvider() )
+    {
+        // Yes, so warn.
+        Con::warnf("GuiSpriteCtrl::setAnimationTimeScale() - Method invalid, not in dynamic (animated) mode.");
+        return;
+    }
+
+    object->setAnimationTimeScale(dAtof(argv[2]));
+}
+
+//-----------------------------------------------------------------------------
+
+/*! Get the animation time scale for this control.
+    @return (float) Returns the animation time scale for this control.
+*/
+ConsoleMethodWithDocs(GuiSpriteCtrl, getAnimationTimeScale, ConsoleFloat, 2, 2, ())
+{
+    // Are we in static mode?
+    if ( object->isStaticFrameProvider() )
+    {
+        // Yes, so warn.
+        Con::warnf("GuiSpriteCtrl::getAnimationTimeScale() - Method invalid, not in dynamic (animated) mode.");
+        return 1.0f;
+    }
+
+    return object->getAnimationTimeScale();
 }
 
 ConsoleMethodGroupEndWithDocs(GuiSpriteCtrl)


### PR DESCRIPTION
These changes make this control functionally similar to the Sprite class.
- fix to set the frame before waking the control
- fix to prevent the frame field from resetting when pushing/popping this control
- named frame support
- improved animation support
- clone functionality added (parent GuiControl is still missing this though)
