### PR TITLE
Taml - Now always outputs bools as 'true' or 'false' rather than '0' or '1'

### DIFF
--- a/engine/source/persistence/taml/taml.cc
+++ b/engine/source/persistence/taml/taml.cc
@@ -680,6 +680,9 @@ void Taml::compileStaticFields( TamlWriteNode* pTamlWriteNode )
             // Fetch object field value.
             const char* pFieldValue = pSimObject->getPrefixedDataField( fieldName, indexBuffer );
 
+            if(pField->type == TypeBool)
+               pFieldValue = dAtob(pFieldValue) ? "true" : "false";
+
             U32 nBufferSize = dStrlen( pFieldValue ) + 1;
             FrameTemp<char> valueCopy( nBufferSize );
             dStrcpy( (char *)valueCopy, pFieldValue );


### PR DESCRIPTION
Optional change, doesn't fix anything just ensures that booleans are written as "true" or "false".. Imo it looks nicer.
