### PR TITLE
Taml - JSON fix

### DIFF
--- a/engine/source/persistence/taml/json/tamlJSONReader.cc
+++ b/engine/source/persistence/taml/json/tamlJSONReader.cc
@@ -663,7 +663,7 @@ inline const char* TamlJSONReader::getTamlObjectName( const rapidjson::Value& va
         StringTableEntry attributeName = StringTable->insert( memberItr->name.GetString() );
 
         // Skip if not the correct attribute.
-        if ( attributeName != tamlRefToIdName )
+        if ( attributeName != tamlNamedObjectName )
             continue;
 
         // Is the value an integer?


### PR DESCRIPTION
This PR has to commits:

One for escaping the jsonText buffer with NULL. - Honestly I have no idea how the JSON reader has ever worked without this change, when I run it the last character is just some random residual character.

Second is for fixing the getTamlObjectName method, which currently looks for a TamlRefId instead of the actual name. - This seems like a simple copy-paste error.
