### PR TITLE
Taml - Now handles 'NULL' values as empty strings

### DIFF
--- a/engine/source/persistence/taml/taml.cc
+++ b/engine/source/persistence/taml/taml.cc
@@ -680,6 +680,9 @@ void Taml::compileStaticFields( TamlWriteNode* pTamlWriteNode )
             // Fetch object field value.
             const char* pFieldValue = pSimObject->getPrefixedDataField( fieldName, indexBuffer );
 
+            if(!pFieldValue)
+               pFieldValue = StringTable->EmptyString;
+
             U32 nBufferSize = dStrlen( pFieldValue ) + 1;
             FrameTemp<char> valueCopy( nBufferSize );
             dStrcpy( (char *)valueCopy, pFieldValue );


### PR DESCRIPTION
An attempt at fixing #79.

Reasoning for this change:

Since writeDataFn should catch it if NULL was an illegal value that shouldn't be written, and if writeDefaults is true we want to write everything, even empty fields, then we can assume that we want to replace the null-value with something to represent the null-value, and since the TorqueScript equivalent of NULL is an empty string, this change seems to make sense.
