### PR TITLE
fix for emscripten builds on case-sensitive systems

### DIFF
--- a/engine/source/platformEmscripten/EmscriptenConsole.cpp
+++ b/engine/source/platformEmscripten/EmscriptenConsole.cpp
@@ -22,7 +22,7 @@
 //-----------------------------------------------------------------------------
 
 #include "platformEmscripten/platformEmscripten.h"
-#include "platformEmscripten/EmscriptenCOnsole.h"
+#include "platformEmscripten/EmscriptenConsole.h"
 #include "platform/event.h"
 #include "game/gameInterface.h"
 

--- a/engine/source/platformEmscripten/EmscriptenConsole.h
+++ b/engine/source/platformEmscripten/EmscriptenConsole.h
@@ -27,7 +27,7 @@
 #include "console/console.h"
 #endif
 #ifndef _EVENT_H_
-#include "Platform/event.h"
+#include "platform/event.h"
 #endif
 
 

--- a/engine/source/platformEmscripten/EmscriptenFont.cpp
+++ b/engine/source/platformEmscripten/EmscriptenFont.cpp
@@ -24,7 +24,7 @@
 #include "platform/platform.h"
 #include "platformEmscripten/platformEmscripten.h"
 #include "platformEmscripten/EmscriptenFont.h"
-#include "string/Unicode.h"
+#include "string/unicode.h"
 
 //------------------------------------------------------------------------------
 // New Unicode capable font class.

--- a/engine/source/platformEmscripten/EmscriptenProcessControl.cpp
+++ b/engine/source/platformEmscripten/EmscriptenProcessControl.cpp
@@ -28,7 +28,7 @@
 #include "game/gameInterface.h"
 
 
-#include <SDL/sdl.h>
+#include <SDL/SDL.h>
 
 void Platform::postQuitMessage(const U32 in_quitVal)
 {

--- a/engine/source/platformEmscripten/platformEmscripten.h
+++ b/engine/source/platformEmscripten/platformEmscripten.h
@@ -29,7 +29,7 @@
 
 #include "platformEmscripten/EmscriptenOGLVideo.h"
 
-#include <SDL/sdl.h>
+#include <SDL/SDL.h>
 
 #define PREF_DIR_ROOT "/.torque"
 #define PREF_DIR_GAME_NAME "T2D"


### PR DESCRIPTION
A ton of files in platformEmscripten had truly strange capitalization
conventions. This PR brings them in line with my Ubuntu box with regards
to ability to build.