### PR TITLE
XML GetText Bug Fix

### DIFF
--- a/engine/source/gui/containers/guiScrollCtrl.cc
+++ b/engine/source/gui/containers/guiScrollCtrl.cc
@@ -136,7 +136,7 @@ bool GuiScrollCtrl::onWake()
       return false;
 
    mTextureHandle = mProfile->mTextureHandle;
-   mTextureHandle.setFilter(GL_NEAREST);;
+   mTextureHandle.setFilter(GL_NEAREST);
 
    bool result;
    result = mProfile->constructBitmapArray() >= BmpStates * BmpCount;

--- a/engine/source/gui/guiBitmapCtrl.cc
+++ b/engine/source/gui/guiBitmapCtrl.cc
@@ -131,7 +131,8 @@ void GuiBitmapCtrl::setBitmap(const char *name, bool resize)
 {
    mBitmapName = StringTable->insert(name);
    if (*mBitmapName) {
-      mTextureHandle = TextureHandle(mBitmapName, TextureHandle::BitmapTexture, true);
+	   mTextureHandle = TextureHandle(mBitmapName, TextureHandle::BitmapTexture, true);
+	   mTextureHandle.setFilter(GL_LINEAR);
 
       // Resize the control to fit the bitmap
       if (resize) {

--- a/engine/source/persistence/SimXMLDocument.cpp
+++ b/engine/source/persistence/SimXMLDocument.cpp
@@ -122,6 +122,17 @@ S32 SimXMLDocument::loadFile(const char* rFileName)
 }
 
 // -----------------------------------------------------------------------------
+// Get true if file loads successfully.
+// -----------------------------------------------------------------------------
+S32 SimXMLDocument::loadPrefFile(const char* rFileName)
+{
+	reset();
+
+	const char* prefsPath = Platform::getPrefsPath(rFileName);
+	return m_qDocument->LoadFile(prefsPath);
+}
+
+// -----------------------------------------------------------------------------
 // Get true if file saves successfully.
 // -----------------------------------------------------------------------------
 S32 SimXMLDocument::saveFile(const char* rFileName)

--- a/engine/source/persistence/SimXMLDocument.h
+++ b/engine/source/persistence/SimXMLDocument.h
@@ -64,7 +64,8 @@ class SimXMLDocument: public SimObject
       void reset(void);
       
       // Read / write / parse XML.
-      S32 loadFile(const char* rFileName);
+	  S32 loadFile(const char* rFileName);
+	  S32 loadPrefFile(const char* rFileName);
       S32 saveFile(const char* rFileName);
       S32 parse(const char* rText);
       

--- a/engine/source/persistence/SimXMLDocument_ScriptBinding.h
+++ b/engine/source/persistence/SimXMLDocument_ScriptBinding.h
@@ -39,6 +39,15 @@ ConsoleMethodWithDocs(SimXMLDocument, loadFile, ConsoleInt, 3, 3, (string fileNa
    return object->loadFile( argv[2] );
 }
 
+/*! Load file from given filename in the user pref folder (AppData on Windows systems). Do not begin the path with a qualifier such as ./ or /
+	@param fileName The name of the desired file
+	@return Returns 1 on success and 0 otherwise
+*/
+ConsoleMethodWithDocs(SimXMLDocument, loadPrefFile, ConsoleInt, 3, 3, (string fileName))
+{
+	return object->loadPrefFile(argv[2]);
+}
+
 /*! Save file to given filename.
     @param fileName A string presenting the filename to save the XML document as
     @return Returns 1 on success, and 0 otherwise


### PR DESCRIPTION
I ran into this bug when I loaded an XML file that had a blank field.  The existing code called ToText() on the FirstChild() of the node, but FirstChild() returns NULL when the current node doesn't have any children.  This resulted in a crash.  I fixed it by wrapping it in an IF statement that checks for a NULL value.  Problem solved.  I thought I should pass it along.

Note: This is my first pull request and I've got a few extra commits in there that are the side effect of the learning process and I'm not sure how I can remove them.  Still, the merge only affects the one file so I'm passing it along anyway.  Hopefully I can iron these thing out in future pull requests.