### PR TITLE
Changed Gui.bitmap to use bilinear filtering

### DIFF
--- a/engine/source/gui/containers/guiScrollCtrl.cc
+++ b/engine/source/gui/containers/guiScrollCtrl.cc
@@ -136,7 +136,7 @@ bool GuiScrollCtrl::onWake()
       return false;
 
    mTextureHandle = mProfile->mTextureHandle;
-   mTextureHandle.setFilter(GL_NEAREST);;
+   mTextureHandle.setFilter(GL_NEAREST);
 
    bool result;
    result = mProfile->constructBitmapArray() >= BmpStates * BmpCount;

--- a/engine/source/gui/guiBitmapCtrl.cc
+++ b/engine/source/gui/guiBitmapCtrl.cc
@@ -131,7 +131,8 @@ void GuiBitmapCtrl::setBitmap(const char *name, bool resize)
 {
    mBitmapName = StringTable->insert(name);
    if (*mBitmapName) {
-      mTextureHandle = TextureHandle(mBitmapName, TextureHandle::BitmapTexture, true);
+	   mTextureHandle = TextureHandle(mBitmapName, TextureHandle::BitmapTexture, true);
+	   mTextureHandle.setFilter(GL_LINEAR);
 
       // Resize the control to fit the bitmap
       if (resize) {


### PR DESCRIPTION
The legacy version of TGB used bilinear filtering on Gui bitmaps.  My game used these bitmaps for the logo and for backgrounds on many menu screens.  These backgrounds looked pixelated without bilinear filtering applied.  My one line fix makes it work as it use to.  I also removed an extra semi-colon.