### PR TITLE
Fixed Bug in XML

### DIFF
--- a/engine/source/persistence/SimXMLDocument.cpp
+++ b/engine/source/persistence/SimXMLDocument.cpp
@@ -811,11 +811,15 @@ const char* SimXMLDocument::getText()
    if(!pNode)
       return "";
 
-   TiXmlText* text = pNode->FirstChild()->ToText();
-   if( !text )
-      return "";
+   if (pNode->FirstChild() != NULL)
+   {
+	   TiXmlText* text = pNode->FirstChild()->ToText();
+	   if (!text)
+		   return "";
 
-   return text->Value();
+	   return text->Value();
+   }
+   else return "";
 }
 
 void SimXMLDocument::removeText()


### PR DESCRIPTION
SimXMLDocument would crash if you tried to read a field that had a blank
value.  This happened because it checks the text of the first child
element when there is no first child element.  This fixes the problem by
checking to see if the first child element is null first.