### PR TITLE
Get and Set for CompositeSprite.SpriteAnimationFrame

### DIFF
--- a/engine/source/2d/core/SpriteBatch.cc
+++ b/engine/source/2d/core/SpriteBatch.cc
@@ -595,6 +595,30 @@ StringTableEntry SpriteBatch::getSpriteAnimation( void ) const
 
 //------------------------------------------------------------------------------
 
+void SpriteBatch::setSpriteAnimationFrame(const U32 animationFrame)
+{
+	// Finish if a sprite is not selected.
+	if (!checkSpriteSelected())
+		return;
+
+	// Set image frame.
+	mSelectedSprite->setAnimationFrame(animationFrame);
+}
+
+//------------------------------------------------------------------------------
+
+U32 SpriteBatch::getSpriteAnimationFrame(void) const
+{
+	// Finish if a sprite is not selected.
+	if (!checkSpriteSelected())
+		return NULL;
+
+	// Get image frame.
+	return mSelectedSprite->getAnimationFrame();
+}
+
+//------------------------------------------------------------------------------
+
 void SpriteBatch::clearSpriteAsset( void )
 {
     // Finish if a sprite is not selected.

--- a/engine/source/2d/core/SpriteBatch.h
+++ b/engine/source/2d/core/SpriteBatch.h
@@ -130,7 +130,9 @@ public:
     void setSpriteNamedImageFrame( const char* namedFrame );
     StringTableEntry getSpriteNamedImageFrame( void ) const;
     void setSpriteAnimation( const char* pAssetId );
-    StringTableEntry getSpriteAnimation( void ) const;
+	StringTableEntry getSpriteAnimation(void) const;
+	void setSpriteAnimationFrame(const U32 animationFrame);
+	U32 getSpriteAnimationFrame(void) const;
     void clearSpriteAsset( void );
 
     void setSpriteVisible( const bool visible );

--- a/engine/source/2d/sceneobject/CompositeSprite_ScriptBinding.h
+++ b/engine/source/2d/sceneobject/CompositeSprite_ScriptBinding.h
@@ -471,6 +471,30 @@ ConsoleMethodWithDocs(CompositeSprite, getSpriteAnimation, ConsoleString, 2, 2, 
 
 //-----------------------------------------------------------------------------
 
+/*! Sets the sprite image frame.
+@param imageFrame The image frame to set the sprite to.
+@return No return value.
+*/
+ConsoleMethodWithDocs(CompositeSprite, setSpriteAnimationFrame, ConsoleVoid, 3, 3, (int animationFrame))
+{
+	// Fetch frame.
+	const U32 frame = dAtoi(argv[2]);
+
+	object->setSpriteAnimationFrame(frame);
+}
+
+//-----------------------------------------------------------------------------
+
+/*! Gets the sprite image frame.
+@return The sprite image frame.
+*/
+ConsoleMethodWithDocs(CompositeSprite, getSpriteAnimationFrame, ConsoleInt, 2, 2, ())
+{
+	return object->getSpriteAnimationFrame();
+}
+
+//-----------------------------------------------------------------------------
+
 /*! Clears any image or animation asset from the sprite.
     @return No return value.
 */

--- a/engine/source/2d/sceneobject/CompositeSprite_ScriptBinding.h
+++ b/engine/source/2d/sceneobject/CompositeSprite_ScriptBinding.h
@@ -471,8 +471,8 @@ ConsoleMethodWithDocs(CompositeSprite, getSpriteAnimation, ConsoleString, 2, 2, 
 
 //-----------------------------------------------------------------------------
 
-/*! Sets the sprite image frame.
-@param imageFrame The image frame to set the sprite to.
+/*! Sets the current animation frame for the selected sprite. IMPORTANT: this is not the image frame number used in the animation!
+@param frame Which frame of the animation to display
 @return No return value.
 */
 ConsoleMethodWithDocs(CompositeSprite, setSpriteAnimationFrame, ConsoleVoid, 3, 3, (int animationFrame))
@@ -485,8 +485,8 @@ ConsoleMethodWithDocs(CompositeSprite, setSpriteAnimationFrame, ConsoleVoid, 3, 
 
 //-----------------------------------------------------------------------------
 
-/*! Gets the sprite image frame.
-@return The sprite image frame.
+/*! Gets current frame index used in the animation for the selected sprite. IMPORTANT: this is not the image frame number!
+@return The current numerical animation frame for the selected sprite
 */
 ConsoleMethodWithDocs(CompositeSprite, getSpriteAnimationFrame, ConsoleInt, 2, 2, ())
 {


### PR DESCRIPTION
Added getSpriteAnimationFrame() and setSpriteAnimationFrame() to CompositeSprites.  Similar functions already existed for static sprites (get/setSpriteImageFrame()) so this just adds matching support for animated sprites within the composite sprite.  Both functions have been tested and work as expected.