### PR TITLE
Fix for the Scene Window Zoom Bug

### DIFF
--- a/engine/source/2d/gui/SceneWindow.cc
+++ b/engine/source/2d/gui/SceneWindow.cc
@@ -1431,13 +1431,6 @@ void SceneWindow::calculateCameraView( CameraView* pCameraView )
         // Recalculate destination area.
         pCameraView->mDestinationArea.point  = pCameraView->mSceneMin;
         pCameraView->mDestinationArea.extent = pCameraView->mSceneMax - pCameraView->mSceneMin;
-
-        // Inset Window by Zoom Factor (if it's big enough to do so).
-        if (    pCameraView->mDestinationArea.extent.x > (zoomFactorX*2.0f) &&
-                pCameraView->mDestinationArea.extent.y > (zoomFactorY*2.0f) )
-        {
-            pCameraView->mDestinationArea.inset( zoomFactorX, zoomFactorY );
-        }
     }
 
     // Calculate Scene Window Scale.


### PR DESCRIPTION
This removes a duplicate code block that was causing the rendering rect
to shrink twice as fast as the window when zooming in which caused
sprites to disappear.  This fixes issue #53 and was originally suggested
by Simon Love.  I compared the file with the original in TGB to make
sure we deleted the correct code block.  This has been tested by Simon
and myself in our projects and in the toys.