### PR TITLE
Canvas.setCursor Windows Fix

### DIFF
--- a/engine/source/gui/guiCanvas.cc
+++ b/engine/source/gui/guiCanvas.cc
@@ -26,6 +26,7 @@
 #include "graphics/dgl.h"
 #include "platform/event.h"
 #include "platform/platform.h"
+#include "platform/platformInput.h"
 #include "platform/platformVideo.h"
 #include "gui/guiTypes.h"
 #include "gui/guiControl.h"
@@ -57,6 +58,7 @@ GuiCanvas::GuiCanvas()
 
    cursorON    = true;
    mShowCursor = false;
+   mUseNativeCursor = true;
 
    lastCursorON = false;
    rLastFrameTime = 0.0f;
@@ -135,6 +137,15 @@ void GuiCanvas::setCursorON(bool onOff)
       mMouseControl = NULL;
 }
 
+bool GuiCanvas::getUseNativeCursor(void)
+{
+   return mUseNativeCursor;
+}
+
+void GuiCanvas::useNativeCursor(bool useNative)
+{
+   mUseNativeCursor = useNative;
+}
 
 void GuiCanvas::setCursorPos(const Point2I &pt)   
 { 
@@ -1295,7 +1306,7 @@ void GuiCanvas::renderFrame(bool preRenderOnly, bool bufferSwap /* = true */)
       dglSetClipRect(updateUnion);
 
       //temp draw the mouse
-      if (cursorON && mShowCursor && !mouseCursor)
+      if (cursorON && mShowCursor && !mouseCursor && Canvas->getUseNativeCursor())
       {
 #if defined(TORQUE_OS_IOS) || defined(TORQUE_OS_ANDROID) || defined(TORQUE_OS_EMSCRIPTEN)
          glColor4ub(255, 0, 0, 255);

--- a/engine/source/gui/guiCanvas.h
+++ b/engine/source/gui/guiCanvas.h
@@ -109,6 +109,7 @@ protected:
    GuiCursor   *defaultCursor;
    GuiCursor   *lastCursor;
    bool        lastCursorON;
+   bool        mUseNativeCursor;
    /// @}
 
    /// @name Mouse Input
@@ -251,6 +252,9 @@ public:
    /// Sets the cursor for the canvas.
    /// @param   cursor   New cursor to use.
    virtual void setCursor(GuiCursor *cursor);
+
+   virtual bool getUseNativeCursor(void);
+   virtual void useNativeCursor(bool useNative);
 
    /// Returns true if the cursor is on.
    virtual bool isCursorON() {return cursorON; }

--- a/engine/source/gui/guiCanvas_ScriptBinding.h
+++ b/engine/source/gui/guiCanvas_ScriptBinding.h
@@ -147,7 +147,19 @@ ConsoleMethodWithDocs( GuiCanvas, setCursor, ConsoleVoid, 3, 3, ( cursorHandle )
          return;
       }
    }
+   Canvas->useNativeCursor(false);
    Canvas->setCursor(curs);
+   Canvas->showCursor(true);
+}
+
+/*! Returns the cursor to the system default.
+    @return No return value
+*/
+ConsoleMethodWithDocs(GuiCanvas, resetCursor, void, 2, 2, ())
+{
+   Canvas->useNativeCursor(true);
+   Canvas->showCursor(false);
+   Input::refreshCursor();
 }
 
 /*! 

--- a/engine/source/platformWin32/winWindow.cc
+++ b/engine/source/platformWin32/winWindow.cc
@@ -1000,6 +1000,10 @@ case WM_MOUSEMOVE:
       Game->postEvent(event);
    }
    break;
+case WM_SETCURSOR:
+   if ((LOWORD(lParam) == HTCLIENT) && !(Canvas->getUseNativeCursor()))
+      SetCursor(NULL);
+   break;
 case WM_LBUTTONDOWN:
    mouseButtonEvent(SI_MAKE, KEY_BUTTON0);
    break;


### PR DESCRIPTION
This fixes issue #78 in Windows.  It was adapted from code written long
ago by Simon Love.  Further testing may be needed on the other platforms
to determine if they also have problems with custom cursors.