### PR TITLE
Support for GCC 5.X Compilers

### DIFF
--- a/engine/source/platform/types.h
+++ b/engine/source/platform/types.h
@@ -170,6 +170,11 @@ inline U32 endianSwap(const U32 in_swap)
 #define Offset(x, cls) _Offset_Normal(x, cls)
 #define OffsetNonConst(x, cls) _Offset_Variant_1(x, cls)
 
+#elif defined(TORQUE_COMPILER_GCC) && (__GNUC__ == 5)
+#include <stddef.h>
+#define Offset(x, cls) offsetof(cls, x)
+#define OffsetNonConst(x, cls) _Offset_Normal(x, cls)
+
 #endif
 #endif
 


### PR DESCRIPTION
This will hopefully correct Issue #252 which appears to only affect
users with ArchLinux.