### PR TITLE
Fix for broken VS2013 solution filters

### DIFF
--- a/engine/compilers/VisualStudio 2013/Torque 2D.vcxproj.filters
+++ b/engine/compilers/VisualStudio 2013/Torque 2D.vcxproj.filters
@@ -3164,6 +3164,7 @@
     </ClInclude>
     <ClInclude Include="..\..\source\audio\vorbisStreamSource.h">
       <Filter>audio</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\source\platformWin32\winVersion.h">
       <Filter>platformWin32</Filter>
     </ClInclude>


### PR DESCRIPTION
Addition of ogg libs broken the VS2013 solution filters. This change
fixes that so the solution explorer shows the filters again.

(Sorry!)