### PR TITLE
Rewrite of ShapeVector class renderer.

### DIFF
--- a/engine/source/2d/sceneobject/ShapeVector.h
+++ b/engine/source/2d/sceneobject/ShapeVector.h
@@ -37,7 +37,6 @@ protected:
     ColorF                  mLineColor;
     ColorF                  mFillColor;
     bool                    mFillMode;
-    Vector2                 mPolygonScale;          ///< Polygon Scale.
     Vector<Vector2>         mPolygonBasisList;      ///< Polygon Basis List.
     Vector<Vector2>         mPolygonLocalList;      ///< Polygon Local List.
     bool                    mIsCircle;
@@ -52,7 +51,6 @@ public:
     static void initPersistFields();
 
     /// Polygon Configuration.
-    void setPolyScale( const Vector2& scale );
     void setPolyPrimitive( const U32 polyVertexCount );
     void setPolyCustom( const U32 polyVertexCount, const char* pCustomPolygon );
     U32 getPolyVertexCount( void ) { return U32(mPolygonBasisList.size()); };
@@ -78,8 +76,8 @@ public:
     /// Internal Crunchers.
     void generateLocalPoly( void );
 
-    void renderCircleShape(Vector2 position, F32 radius);
-    void renderPolygonShape(U32 vertexCount);
+    void renderCircleShape(Vector2 position, F32 radius, const bool wireFrame);
+    void renderPolygonShape(U32 vertexCount, const bool wireFrame);
 
     /// Render flipping.
     inline void setFlip( const bool flipX, const bool flipY )   { mFlipX = flipX; mFlipY = flipY; generateLocalPoly(); }

--- a/engine/source/2d/sceneobject/ShapeVector_ScriptBinding.h
+++ b/engine/source/2d/sceneobject/ShapeVector_ScriptBinding.h
@@ -22,43 +22,6 @@
 
 ConsoleMethodGroupBeginWithDocs(ShapeVector, SceneObject)
 
-/*! Sets the polygon scale.
-    @param width/heightScale The scale values of the given polygon. If no height is specified, the widthScale value is repeated.
-    @return No return value.
-*/
-ConsoleMethodWithDocs(ShapeVector, setPolyScale, ConsoleVoid, 3, 3, (widthScale / [heightScale]))
-{
-    // Calculate Element Count.
-    const U32 elementCount = Utility::mGetStringElementCount( argv[2] );
-
-    // Check Parameters.
-    if ( elementCount < 1 )
-    {
-        Con::warnf("ShapeVector::setPolyScale() - Invalid number of parameters!");
-        return;
-    }
-
-    // Fetch Width Scale.
-    Vector2 scale;
-    scale.x = dAtof(Utility::mGetStringElement(argv[2],0));
-    // Use Fixed-Aspect for Scale if Height-Scale not specified.
-    if ( elementCount == 2 )
-    {
-        // Specified Height Scale.
-        scale.y = dAtof(Utility::mGetStringElement(argv[2],1));
-    }
-    else
-    {
-        // Fixed-Aspect Scale.
-        scale.y = scale.x;
-    }
-
-    // Set Polygon Scale.
-    object->setPolyScale( scale );
-}
-
-//----------------------------------------------------------------------------
-
 /*! Sets a regular polygon primitive.
     @return No return value.
 */


### PR DESCRIPTION
ShapeVector should now render correctly on all platforms.

Removed unused setPolyScale() method.

Hopefully resolves issues #156, #107 (and #149 for ShapeVector only).