### PR TITLE
Remove OSX-specific password mask bullet character to prevent crash

### DIFF
--- a/engine/source/gui/guiTextEditCtrl.cc
+++ b/engine/source/gui/guiTextEditCtrl.cc
@@ -66,14 +66,7 @@ GuiTextEditCtrl::GuiTextEditCtrl()
 
    mValidateCommand = StringTable->EmptyString;
    mEscapeCommand = StringTable->EmptyString;
-#ifdef TORQUE_OS_OSX
-   UTF8	bullet[4] = { static_cast<UTF8>(0xE2), static_cast<UTF8>(0x80), static_cast<UTF8>(0xA2), 0 };
-   
-   mPasswordMask = StringTable->insert( bullet );
-#else
    mPasswordMask = StringTable->insert( "*" );
-#endif
-
 
    mEditCursor = NULL;
 }


### PR DESCRIPTION
Removes the bullet password mask for OSX to prevent crashes relating to the character encoding being wrong when the font glyph is looked up, which happens when password fields are selected.

Addresses #134 

Note: This change was tested on master since it still builds on OSX, development does not build on OSX after the ogg additions.