### PR TITLE
Pointers can get cast to this type, so use uintptr_t.

### DIFF
--- a/engine/source/platform/types.posix.h
+++ b/engine/source/platform/types.posix.h
@@ -23,13 +23,14 @@
 #ifndef _TYPESPOSIX_H_
 #define _TYPESPOSIX_H_
 
+#include <stdint.h>
 
 #define FN_CDECL     ///< Calling convention
 
 // size_t is needed to overload new
 // size_t tends to be OS and compiler specific and may need to 
 // be if/def'ed in the future
-typedef unsigned int  dsize_t;      
+typedef uintptr_t  dsize_t;
 
 
 /** Platform dependent file date-time structure.  The defination of this structure


### PR DESCRIPTION
I was getting this error on OpenBSD:

    Building debug object Debug/2d/scene/Scene.cc.o
    gcc -c -I/usr/local/include -I../../source -ggdb -DTORQUE_DEBUG -DTORQUE_DEBUG_GUARD -DTORQUE_NET_STATS ../../source/2d/scene/Scene.cc -o Debug/2d/scene/Scene.cc.o
    In file included from ../../source/platform/types.gcc.h:85,
                     from ../../source/platform/types.h:87,
                     from ../../source/platform/platform.h:31,
                     from ../../source/math/mPoint.h:32,
                     from ../../source/math/mMath.h:27,
                     from ../../source/2d/scene/Scene.h:27,
                     from ../../source/2d/scene/Scene.cc:24:
    ../../source/platform/types.posix.h:32:2: error: #error
    ../../source/2d/scene/Scene.cc: In static member function 'static void Scene::initPersistFields()':
    ../../source/2d/scene/Scene.cc:315: error: cast from 'SceneRenderQueue::RenderSort*' to 'dsize_t' loses precision
    Torque2D:464: recipe for target 'Debug/2d/scene/Scene.cc.o' failed
    gmake: *** [Debug/2d/scene/Scene.cc.o] Error 1

So this seems to require an integer type big enough to hold a pointer.