### PR TITLE
Remove stray byte order marks from C source files.

### DIFF
--- a/engine/source/2d/assets/AnimationAsset_ScriptBinding.h
+++ b/engine/source/2d/assets/AnimationAsset_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/2d/assets/ImageAsset_ScriptBinding.h
+++ b/engine/source/2d/assets/ImageAsset_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/2d/controllers/AmbientForceController_ScriptBinding.h
+++ b/engine/source/2d/controllers/AmbientForceController_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/2d/controllers/BuoyancyController_ScriptBinding.h
+++ b/engine/source/2d/controllers/BuoyancyController_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/2d/controllers/core/PickingSceneController_ScriptBinding.h
+++ b/engine/source/2d/controllers/core/PickingSceneController_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/2d/core/RenderProxy_ScriptBinding.h
+++ b/engine/source/2d/core/RenderProxy_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/2d/core/SpriteBase_ScriptBinding.h
+++ b/engine/source/2d/core/SpriteBase_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/2d/core/Utility_ScriptBinding.h
+++ b/engine/source/2d/core/Utility_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/2d/gui/SceneWindow_ScriptBinding.h
+++ b/engine/source/2d/gui/SceneWindow_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/2d/gui/guiImageButtonCtrl_ScriptBindings.h
+++ b/engine/source/2d/gui/guiImageButtonCtrl_ScriptBindings.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/2d/gui/guiSpriteCtrl_ScriptBindings.h
+++ b/engine/source/2d/gui/guiSpriteCtrl_ScriptBindings.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/2d/scene/Scene_ScriptBinding.h
+++ b/engine/source/2d/scene/Scene_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/2d/sceneobject/CompositeSprite_ScriptBinding.h
+++ b/engine/source/2d/sceneobject/CompositeSprite_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/2d/sceneobject/SceneObjectSet_ScriptBinding.h
+++ b/engine/source/2d/sceneobject/SceneObjectSet_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/2d/sceneobject/SceneObject_ScriptBinding.h
+++ b/engine/source/2d/sceneobject/SceneObject_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/2d/sceneobject/Scroller_ScriptBinding.h
+++ b/engine/source/2d/sceneobject/Scroller_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/2d/sceneobject/ShapeVector_ScriptBinding.h
+++ b/engine/source/2d/sceneobject/ShapeVector_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/2d/sceneobject/Sprite_ScriptBinding.h
+++ b/engine/source/2d/sceneobject/Sprite_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/assets/assetBase_ScriptBinding.h
+++ b/engine/source/assets/assetBase_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/assets/assetManager_ScriptBinding.h
+++ b/engine/source/assets/assetManager_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/assets/assetQuery_ScriptBinding.h
+++ b/engine/source/assets/assetQuery_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/assets/assetTagsManifest_ScriptBinding.h
+++ b/engine/source/assets/assetTagsManifest_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/audio/audio_ScriptBinding.cc
+++ b/engine/source/audio/audio_ScriptBinding.cc
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/collection/nameTags_ScriptBinding.h
+++ b/engine/source/collection/nameTags_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/collection/undo_ScriptBinding.h
+++ b/engine/source/collection/undo_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/component/behaviors/behaviorComponent_ScriptBinding.h
+++ b/engine/source/component/behaviors/behaviorComponent_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/component/behaviors/behaviorInstance_ScriptBinding.h
+++ b/engine/source/component/behaviors/behaviorInstance_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/component/behaviors/behaviorTemplate_ScriptBinding.h
+++ b/engine/source/component/behaviors/behaviorTemplate_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/component/dynamicConsoleMethodComponent_ScriptBinding.h
+++ b/engine/source/component/dynamicConsoleMethodComponent_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/component/simComponent_ScriptBinding.h
+++ b/engine/source/component/simComponent_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/console/consoleDoc_ScriptBinding.h
+++ b/engine/source/console/consoleDoc_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/console/consoleExprEvalState_ScriptBinding.h
+++ b/engine/source/console/consoleExprEvalState_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/console/consoleLogger_ScriptBinding.h
+++ b/engine/source/console/consoleLogger_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/console/consoleNamespace_ScriptBinding.h
+++ b/engine/source/console/consoleNamespace_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/console/expando_ScriptBinding.h
+++ b/engine/source/console/expando_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/console/inputManagement_ScriptBinding.h
+++ b/engine/source/console/inputManagement_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/console/metaScripting_ScriptBinding.cc
+++ b/engine/source/console/metaScripting_ScriptBinding.cc
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/console/output_ScriptBinding.h
+++ b/engine/source/console/output_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/console/taggedStrings_ScriptBinding.h
+++ b/engine/source/console/taggedStrings_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/debug/profiler_ScriptBinding.h
+++ b/engine/source/debug/profiler_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/debug/remote/RemoteDebugger1_ScriptBinding.h
+++ b/engine/source/debug/remote/RemoteDebugger1_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/debug/remote/RemoteDebuggerBase_ScriptBinding.h
+++ b/engine/source/debug/remote/RemoteDebuggerBase_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/debug/remote/RemoteDebuggerBridge_ScriptBinding.h
+++ b/engine/source/debug/remote/RemoteDebuggerBridge_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/debug/telnetDebugger_ScriptBinding.h
+++ b/engine/source/debug/telnetDebugger_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/game/gameConnection_ScriptBinding.h
+++ b/engine/source/game/gameConnection_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/game/gameInterface_ScriptBinding.h
+++ b/engine/source/game/gameInterface_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/game/version_ScriptBinding.h
+++ b/engine/source/game/version_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/graphics/PNGImage_ScriptBinding.h
+++ b/engine/source/graphics/PNGImage_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/graphics/TextureManager_ScriptBinding.h
+++ b/engine/source/graphics/TextureManager_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/graphics/color_ScriptBinding.h
+++ b/engine/source/graphics/color_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/graphics/dglMac_ScriptBinding.h
+++ b/engine/source/graphics/dglMac_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/graphics/dgl_ScriptBinding.h
+++ b/engine/source/graphics/dgl_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/graphics/gFont_ScriptBinding.h
+++ b/engine/source/graphics/gFont_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/gui/guiCanvas_ScriptBinding.h
+++ b/engine/source/gui/guiCanvas_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/gui/guiControl_ScriptBinding.h
+++ b/engine/source/gui/guiControl_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/input/actionMap_ScriptBinding.h
+++ b/engine/source/input/actionMap_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/io/fileObject_ScriptBinding.h
+++ b/engine/source/io/fileObject_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/io/fileStreamObject_ScriptBinding.h
+++ b/engine/source/io/fileStreamObject_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/io/fileSystem_ScriptBinding.cc
+++ b/engine/source/io/fileSystem_ScriptBinding.cc
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/io/resource/resourceManager_ScriptBinding.h
+++ b/engine/source/io/resource/resourceManager_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/io/streamObject_ScriptBinding.h
+++ b/engine/source/io/streamObject_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/io/zip/zipObject_ScriptBinding.h
+++ b/engine/source/io/zip/zipObject_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/math/math_ScriptBinding.cc
+++ b/engine/source/math/math_ScriptBinding.cc
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/math/matrix_ScriptBinding.h
+++ b/engine/source/math/matrix_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/math/random_ScriptBinding.h
+++ b/engine/source/math/random_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/math/vector_ScriptBinding.h
+++ b/engine/source/math/vector_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/messaging/dispatcher_ScriptBinding.h
+++ b/engine/source/messaging/dispatcher_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/messaging/eventManager_ScriptBinding.h
+++ b/engine/source/messaging/eventManager_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/messaging/message_ScriptBinding.h
+++ b/engine/source/messaging/message_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/module/moduleDefinition_ScriptBinding.h
+++ b/engine/source/module/moduleDefinition_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/module/moduleManager_ScriptBinding.h
+++ b/engine/source/module/moduleManager_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/network/RemoteCommandEvent_ScriptBinding.h
+++ b/engine/source/network/RemoteCommandEvent_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/network/httpObject_ScriptBinding.h
+++ b/engine/source/network/httpObject_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/network/netConnection_ScriptBinding.h
+++ b/engine/source/network/netConnection_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/network/netInterface_ScriptBinding.h
+++ b/engine/source/network/netInterface_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/network/netObject_ScriptBinding.h
+++ b/engine/source/network/netObject_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/network/netStringTable_ScriptBinding.h
+++ b/engine/source/network/netStringTable_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/network/serverQuery_ScriptBinding.h
+++ b/engine/source/network/serverQuery_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/network/tcpObject_ScriptBinding.h
+++ b/engine/source/network/tcpObject_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/network/telnetConsole_ScriptBinding.h
+++ b/engine/source/network/telnetConsole_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/persistence/SimXMLDocument_ScriptBinding.h
+++ b/engine/source/persistence/SimXMLDocument_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/persistence/taml/taml_ScriptBinding.h
+++ b/engine/source/persistence/taml/taml_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/platform/CursorManager_ScriptBinding.h
+++ b/engine/source/platform/CursorManager_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/platform/menus/popupMenu_ScriptBinding.h
+++ b/engine/source/platform/menus/popupMenu_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/platform/nativeDialogs/fileDialog_ScriptBinding.h
+++ b/engine/source/platform/nativeDialogs/fileDialog_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/platform/nativeDialogs/msgBox_ScriptBinding.h
+++ b/engine/source/platform/nativeDialogs/msgBox_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/platform/platformFileIO_ScriptBinding.h
+++ b/engine/source/platform/platformFileIO_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/platform/platformInput_ScriptBinding.h
+++ b/engine/source/platform/platformInput_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/platform/platformNetwork_ScriptBinding.cc
+++ b/engine/source/platform/platformNetwork_ScriptBinding.cc
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/platform/platformString_ScriptBinding.h
+++ b/engine/source/platform/platformString_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/platform/platformVideo_ScriptBinding.h
+++ b/engine/source/platform/platformVideo_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/platform/platform_ScriptBinding.h
+++ b/engine/source/platform/platform_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/sim/simDatablock_ScriptBinding.h
+++ b/engine/source/sim/simDatablock_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/sim/simObject_ScriptBinding.h
+++ b/engine/source/sim/simObject_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/sim/simSerialize_ScriptBinding.h
+++ b/engine/source/sim/simSerialize_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/sim/simSet_ScriptBinding.h
+++ b/engine/source/sim/simSet_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/string/stringBuffer_ScriptBinding.h
+++ b/engine/source/string/stringBuffer_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/engine/source/string/stringUnit_ScriptBinding.h
+++ b/engine/source/string/stringUnit_ScriptBinding.h
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Copyright (c) 2013 GarageGames, LLC
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
I was getting this on OpenBSD with GCC 4.2.1:

    Building debug object Debug/assets/assetManager.cc.o
    gcc -c -I/usr/local/include -I../../source -ggdb -DTORQUE_DEBUG -DTORQUE_DEBUG_GUARD -DTORQUE_NET_STATS ../../source/assets/assetManager.cc -o Debug/assets/assetManager.cc.o
    In file included from ../../source/assets/assetManager.cc:58:
    ../../source/assets/assetManager_ScriptBinding.h:1: error: stray '\357' in program
    ../../source/assets/assetManager_ScriptBinding.h:1: error: stray '\273' in program
    ../../source/assets/assetManager_ScriptBinding.h:1: error: stray '\277' in program
    Torque2D:464: recipe for target 'Debug/assets/assetManager.cc.o' failed
    gmake: *** [Debug/assets/assetManager.cc.o] Error 1