### PR TITLE
Fix "make clean" on strict POSIX platforms (those without rm -v).

### DIFF
--- a/engine/compilers/Make/Makefile
+++ b/engine/compilers/Make/Makefile
@@ -9,9 +9,9 @@ APP_TARGETS_DEBUG :=
 all: debug release
 
 clean:
-	rm -rfv Debug
-	rm -rfv Release
-	rm -rfv lib
+	rm -rf Debug
+	rm -rf Release
+	rm -rf lib
 
 .PHONY: all debug release clean
 


### PR DESCRIPTION
For example, OpenBSD doesn't have `rm -v`, so "make clean" fails.