### PR TITLE
On some platforms time.h seems to get included. Avoid time() collision.

### DIFF
--- a/engine/source/platformX86UNIX/x86UNIXCPUInfo.cc
+++ b/engine/source/platformX86UNIX/x86UNIXCPUInfo.cc
@@ -39,7 +39,7 @@ void detectX86CPUInfo(char *vendor, U32 *processor, U32 *properties);
 }
 
 /* used in the asm */
-static U32 time[2];
+static U32 Ttime[2];
 static U32 clockticks = 0;
 static char vendor[13] = {0,};
 static U32 properties = 0;
@@ -59,7 +59,7 @@ void Processor::init()
    PlatformSystemInfo.processor.mhz  = 0;
    PlatformSystemInfo.processor.properties = CPU_PROP_C;
 
-   clockticks = properties = processor = time[0] = 0;
+   clockticks = properties = processor = Ttime[0] = 0;
    dStrcpy(vendor, "");
 
    detectX86CPUInfo(vendor, &processor, &properties);
@@ -82,8 +82,8 @@ void Processor::init()
          "pushl  %eax\n"
          "pushl  %edx\n"
          "rdtsc\n"
-         "movl   %eax, (time)\n"
-         "movl   %edx, (time+4)\n"
+         "movl   %eax, (Ttime)\n"
+         "movl   %edx, (Ttime+4)\n"
          "popl   %edx\n"
          "popl   %eax\n"
          );
@@ -102,8 +102,8 @@ void Processor::init()
          "pushl  %eax\n"
          "pushl  %edx\n"
          "rdtsc\n"
-         "sub    (time+4), %edx\n"
-         "sbb    (time), %eax\n"
+         "sub    (Ttime+4), %edx\n"
+         "sbb    (Ttime), %eax\n"
          "mov    %eax, (clockticks)\n"
          "popl   %edx\n"
          "popl   %eax\n"


### PR DESCRIPTION
I hit this on OpenBSD:

    gcc -c -I../../lib/ljpeg -I../../source/persistence/rapidjson/include -I../../source -I/usr/local/include -ggdb -DTORQUE_DEBUG -DTORQUE_DEBUG_GUARD -DTORQUE_NET_STATS ../../source/platformX86UNIX/x86UNIXCPUInfo.cc -o Debug/platformX86UNIX/x86UNIXCPUInfo.cc.o
    ../../source/platformX86UNIX/x86UNIXCPUInfo.cc:42: error: 'U32 time [2]' redeclared as different kind of symbol
    /usr/include/time.h:136: error: previous declaration of 'time_t time(time_t*)'
    ../../source/platformX86UNIX/x86UNIXCPUInfo.cc: In static member function 'static void Processor::init()':
    ../../source/platformX86UNIX/x86UNIXCPUInfo.cc:62: error: pointer to a function used in arithmetic
    ../../source/platformX86UNIX/x86UNIXCPUInfo.cc:62: error: assignment of function 'time_t time(time_t*)'
    ../../source/platformX86UNIX/x86UNIXCPUInfo.cc:62: error: cannot convert 'int' to 'time_t ()(time_t*)' in assignment
    Torque2D:464: recipe for target 'Debug/platformX86UNIX/x86UNIXCPUInfo.cc.o' failed
    gmake: *** [Debug/platformX86UNIX/x86UNIXCPUInfo.cc.o] Error 1