### PR TITLE
Add ifdefs for OpenBSD codepaths.

### DIFF
--- a/engine/source/audio/audio.cc
+++ b/engine/source/audio/audio.cc
@@ -2474,7 +2474,7 @@ bool OpenALInit()
       return false;
 
    // Create an openAL context
-#ifdef TORQUE_OS_LINUX
+#if defined(TORQUE_OS_LINUX) || defined(TORQUE_OS_OPENBSD)
    int freq = Con::getIntVariable("Pref::Unix::OpenALFrequency");
    if (freq == 0)
       freq = 22050;
@@ -2504,7 +2504,7 @@ bool OpenALInit()
       return false;
 
    // Make this context the active context
-#if defined(TORQUE_OS_ANDROID) || defined(TORQUE_OS_LINUX) || defined(TORQUE_OS_EMSCRIPTEN)
+#if defined(TORQUE_OS_ANDROID) || defined(TORQUE_OS_LINUX) || defined(TORQUE_OS_EMSCRIPTEN) || defined(TORQUE_OS_OPENBSD)
    alcMakeContextCurrent((ALCcontext*)mContext);
 #else
    alcMakeContextCurrent(mContext);
@@ -2590,7 +2590,7 @@ void OpenALShutdown()
 
    if (mContext)
    {
-#if defined(TORQUE_OS_ANDROID) || defined(TORQUE_OS_LINUX)
+#if defined(TORQUE_OS_ANDROID) || defined(TORQUE_OS_LINUX) || defined(TORQUE_OS_OPENBSD)
 	   alcDestroyContext((ALCcontext*)mContext);
 #elif defined(TORQUE_OS_EMSCRIPTEN)
       alcDestroyContext((ALCcontext*)mContext);
@@ -2602,7 +2602,7 @@ void OpenALShutdown()
    }
    if (mDevice)
    {
-#if defined(TORQUE_OS_ANDROID) || defined(TORQUE_OS_LINUX)
+#if defined(TORQUE_OS_ANDROID) || defined(TORQUE_OS_LINUX) || defined(TORQUE_OS_OPENBSD)
 	   alcCloseDevice((ALCdevice*)mDevice);
 #elif defined(TORQUE_OS_EMSCRIPTEN)
       alcCloseDevice((ALCdevice*)mDevice);

--- a/engine/source/platform/platformAL.h
+++ b/engine/source/platform/platformAL.h
@@ -35,7 +35,7 @@
 //Android uses openal soft from https://github.com/AerialX/openal-soft-android
 #include <AL/al.h>
 #include <AL/alc.h>
-#elif defined(TORQUE_OS_LINUX)
+#elif defined(TORQUE_OS_LINUX) || defined(TORQUE_OS_OPENBSD)
 #include <AL/al.h>
 #include <AL/alc.h>
 #include "platform/eaxtypes.h"

--- a/engine/source/platform/platformFileIO.h
+++ b/engine/source/platform/platformFileIO.h
@@ -26,7 +26,7 @@
 #include "platform/platform.h"
 #endif
 
-#ifdef TORQUE_OS_LINUX
+#if defined(TORQUE_OS_LINUX) || defined(TORQUE_OS_OPENBSD)
 // Need to remove this once Xlib stops leaking
 #undef Status
 #endif

--- a/engine/source/platformX86UNIX/x86UNIXProcessControl.cc
+++ b/engine/source/platformX86UNIX/x86UNIXProcessControl.cc
@@ -145,7 +145,7 @@ void ProcessControlInit()
 
    // we're not interested in the exit status of child processes, so this 
    // prevents zombies from accumulating.
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
    signal(SIGCHLD, SIG_IGN);
 #else
    signal(SIGCLD, SIG_IGN);


### PR DESCRIPTION
OpenBSD needs to take these codepaths. Generally, it acts closest to a desktop Linux.