### PR TITLE
WorldQuery Now Treats Objects with No Area as Invisible

### DIFF
--- a/engine/source/2d/scene/WorldQuery.cc
+++ b/engine/source/2d/scene/WorldQuery.cc
@@ -719,8 +719,8 @@ bool WorldQuery::QueryCallback( S32 proxyId )
     if ( mQueryFilter.mEnabledFilter && !pSceneObject->isEnabled() )
         return true;
 
-    // Visible filter.
-    if ( mQueryFilter.mVisibleFilter && !pSceneObject->getVisible() )
+    // Visible filter.  If an object has a size x or y value of zero then they are treated here as invisible.
+    if (mQueryFilter.mVisibleFilter && (!pSceneObject->getVisible() || pSceneObject->getSize().isXZero() || pSceneObject->getSize().isYZero()))
         return true;
 
     // Picking allowed filter.


### PR DESCRIPTION
The WorldQuery class is responsible for finding objects in the scene
both for things like user requested picking and for handing out mouse
events.  In the second case, an assertion error was being thrown when an
object had zero area (sizeX = 0 or sizeY = 0) and the engine tried to
test it for mouse over events.  This was pointless of course because a
point cannot be inside an object with no area.  This change treats
objects without an area as invisible so they cannot be picked without
picking routine also looking for invisible objects.