### PR TITLE
Debug from VisualStudio Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .LSOverride
 /tmp/*
 /preferences.cs
+/engine/**/preferences.cs
 *.dso
 *.edso
 *.user

--- a/engine/compilers/VisualStudio 2013/main.cs
+++ b/engine/compilers/VisualStudio 2013/main.cs
@@ -1,0 +1,25 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) 2013 GarageGames, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//-----------------------------------------------------------------------------
+
+// This file simply points to the real main.cs file in the root of the working directory.
+// This is needed if the project is run in debug mode from within VisualStudio.
+exec("../../../main.cs");

--- a/engine/compilers/VisualStudio 2015/main.cs
+++ b/engine/compilers/VisualStudio 2015/main.cs
@@ -1,0 +1,25 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) 2013 GarageGames, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//-----------------------------------------------------------------------------
+
+// This file simply points to the real main.cs file in the root of the working directory.
+// This is needed if the project is run in debug mode from within VisualStudio.
+exec("../../../main.cs");

--- a/main.cs
+++ b/main.cs
@@ -54,7 +54,7 @@ AssetDatabase.EchoInfo = false;
 AssetDatabase.IgnoreAutoUnload = true;
 
 // Scan modules.
-ModuleDatabase.scanModules( "modules" );
+ModuleDatabase.scanModules( "./modules" );
 
 // Load AppCore module.
 ModuleDatabase.LoadExplicit( "AppCore" );


### PR DESCRIPTION
This creates some extra main.cs files into the project folder for VS
2013 and VS2015.  This allow the debug mode of VS to be used without
having to modify the default user settings created by VS.