### PR TITLE
Make clean fix

### DIFF
--- a/engine/compilers/Make/Makefile
+++ b/engine/compilers/Make/Makefile
@@ -9,9 +9,9 @@ APP_TARGETS_DEBUG :=
 all: debug release
 
 clean:
-	rm -rfv Debug
-	rm -rfv Release
-	rm -rfv lib
+	rm -rf Debug
+	rm -rf Release
+	rm -rf lib
 
 .PHONY: all debug release clean
 


### PR DESCRIPTION
Fixes "make clean" on systems that do not have the -v switch for rm. Duplicate of #291 which was submitted against master, rather than development. 

Resolves #306.