### PR TITLE
Fix building errors and warnings under Android Studio

### DIFF
--- a/engine/compilers/android-studio/app/build.gradle
+++ b/engine/compilers/android-studio/app/build.gradle
@@ -1,14 +1,15 @@
 apply plugin: 'com.android.application'
 
+import org.apache.tools.ant.taskdefs.condition.Os
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 22
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         applicationId "com.garagegames.torque2d"
-        minSdkVersion 19
-        targetSdkVersion 19
+        minSdkVersion 22
+        targetSdkVersion 22
 
         sourceSets.main {
             assets.srcDirs=[
@@ -21,7 +22,8 @@ android {
         }
         task buildNative(type: Exec, description: 'Compile JNI source via NDK') {
             def ndkDir = plugins.getPlugin('com.android.application').sdkHandler.getNdkFolder()
-            commandLine "$ndkDir/ndk-build",
+            def extension = (Os.isFamily(Os.FAMILY_WINDOWS))? '.cmd' : ''
+            commandLine "$ndkDir/ndk-build" + extension,
                     '-C', file('src/main/jni').absolutePath,
                     '-j', Runtime.runtime.availableProcessors(),
                     'all',
@@ -30,7 +32,8 @@ android {
 
         task cleanNative(type: Exec, description: 'Clean JNI object files') {
             def ndkDir = plugins.getPlugin('com.android.application').sdkHandler.getNdkFolder()
-            commandLine "$ndkDir/ndk-build",
+            def extension = (Os.isFamily(Os.FAMILY_WINDOWS))? '.cmd' : ''
+            commandLine "$ndkDir/ndk-build" + extension,
                     '-C', file('src/main/jni').absolutePath,
                     'clean'
         }

--- a/engine/source/2d/scene/ContactFilter.cc
+++ b/engine/source/2d/scene/ContactFilter.cc
@@ -75,8 +75,8 @@ bool ContactFilter::ShouldCollide(b2Fixture* pFixtureA, b2Fixture* pFixtureB)
 bool ContactFilter::FilterOneWay(SceneObject* pSceneObjectA, SceneObject* pSceneObjectB, b2Fixture* pFixtureA, b2Fixture* pFixtureB)
 {
     // One way collisions only apply to edge or chain shapes.
-    if ((pFixtureA->GetType() == b2Shape::Type::e_chain || pFixtureA->GetType() == b2Shape::Type::e_edge) ||
-        (pFixtureB->GetType() == b2Shape::Type::e_chain || pFixtureB->GetType() == b2Shape::Type::e_edge))
+    if ((pFixtureA->GetType() == b2Shape::e_chain || pFixtureA->GetType() == b2Shape::e_edge) ||
+        (pFixtureB->GetType() == b2Shape::e_chain || pFixtureB->GetType() == b2Shape::e_edge))
     {
         // Convenience renaming.
         SceneObject* pPlatformObject = NULL;
@@ -103,7 +103,7 @@ bool ContactFilter::FilterOneWay(SceneObject* pSceneObjectA, SceneObject* pScene
         b2Vec2 shapeCentroid;
         b2AABB* box = new b2AABB();
 
-        if (pFixturePlatform->GetType() == b2Shape::Type::e_chain)
+        if (pFixturePlatform->GetType() == b2Shape::e_chain)
         {
             const b2ChainShape* shape = pPlatformObject->getCollisionChainShape(0);
             shape->ComputeAABB(box, pPlatformObject->getTransform(), 0);

--- a/engine/source/2d/sceneobject/ShapeVector.cc
+++ b/engine/source/2d/sceneobject/ShapeVector.cc
@@ -142,7 +142,7 @@ void ShapeVector::sceneRender( const SceneRenderState* pSceneRenderState, const 
         glRotatef( mRadToDeg(getRenderAngle()), 0.0f, 0.0f, 1.0f );
 
         // Render the shape.
-        bool wireFrame = (pBatchRenderer->getWireframeMode() || this->getDebugMask() & Scene::DebugOption::SCENE_DEBUG_WIREFRAME_RENDER) ? true : false;
+        bool wireFrame = (pBatchRenderer->getWireframeMode() || this->getDebugMask() & Scene::SCENE_DEBUG_WIREFRAME_RENDER) ? true : false;
         renderCircleShape(position, mCircleRadius, wireFrame);
     }
     else
@@ -152,7 +152,7 @@ void ShapeVector::sceneRender( const SceneRenderState* pSceneRenderState, const 
         glRotatef( mRadToDeg(getRenderAngle()), 0.0f, 0.0f, 1.0f );
 
         // Render the shape.
-        bool wireFrame = (pBatchRenderer->getWireframeMode() || this->getDebugMask() & Scene::DebugOption::SCENE_DEBUG_WIREFRAME_RENDER) ? true : false;
+        bool wireFrame = (pBatchRenderer->getWireframeMode() || this->getDebugMask() & Scene::SCENE_DEBUG_WIREFRAME_RENDER) ? true : false;
         renderPolygonShape(vertexCount, wireFrame);
     }
 

--- a/engine/source/audio/audio.cc
+++ b/engine/source/audio/audio.cc
@@ -733,7 +733,7 @@ AUDIOHANDLE alxCreateSource(const Audio::Description& desc,
          if (streamSource)
          {
             streamSource->mHandle = getNewHandle() | AUDIOHANDLE_STREAMING_BIT | AUDIOHANDLE_INACTIVE_BIT;
-            streamSource->mSource = NULL;
+            streamSource->mSource = 0;
             streamSource->mDescription = desc;
             streamSource->mScore = volume;
             streamSource->mEnvironment = sampleEnvironment;

--- a/engine/source/audio/vorbisStreamSource.cc
+++ b/engine/source/audio/vorbisStreamSource.cc
@@ -81,7 +81,7 @@ void VorbisStreamSource::clear()
       freeStream();
 
    mHandle           = NULL_AUDIOHANDLE;
-   mSource           = NULL;
+   mSource           = 0;
 
    if(mBufferList[0] != 0)
       alDeleteBuffers(NUMBUFFERS, mBufferList);

--- a/engine/source/audio/wavStreamSource.cc
+++ b/engine/source/audio/wavStreamSource.cc
@@ -128,7 +128,7 @@ void WavStreamSource::clear()
         freeStream();
 
     mHandle           = NULL_AUDIOHANDLE;
-    mSource			  = NULL;
+    mSource			  = 0;
 
     if(mBufferList[0] != 0)
         alDeleteBuffers(NUMBUFFERS, mBufferList);

--- a/engine/source/collection/nameTags_ScriptBinding.h
+++ b/engine/source/collection/nameTags_ScriptBinding.h
@@ -80,7 +80,7 @@ ConsoleMethodWithDocs(NameTags, deleteTag, ConsoleInt, 3, 3, (tagId))
     if ( tagId == 0 )
     {
         Con::warnf("Invalid tag Id.\n");
-        return NULL;
+        return 0;
     }
 
     return object->deleteTag( tagId );

--- a/engine/source/delegates/delegateSignal.h
+++ b/engine/source/delegates/delegateSignal.h
@@ -54,7 +54,7 @@ public:
    {
       mList.next = mList.prev = &mList;
       mList.order = 0.5f;
-      mTriggerNext = NULL;
+      //mTriggerNext = NULL;
    }
 
    ~SignalBase();

--- a/engine/source/gui/guiCanvas_ScriptBinding.h
+++ b/engine/source/gui/guiCanvas_ScriptBinding.h
@@ -256,7 +256,7 @@ ConsoleMethodWithDocs( GuiCanvas, getMouseControl, ConsoleInt, 2, 2, ())
    if (control)
       return control->getId();
    
-   return NULL;
+   return 0;
 }
 
 //-----------------------------------------------------------------------------

--- a/engine/source/persistence/taml/json/tamlJSONReader.cc
+++ b/engine/source/persistence/taml/json/tamlJSONReader.cc
@@ -45,7 +45,7 @@ SimObject* TamlJSONReader::read( FileStream& stream )
         Con::warnf("TamlJSONReader::read() -  Could not load Taml JSON file from stream.");
         return NULL;
     }
-    jsonText[streamSize] = NULL;
+    jsonText[streamSize] = '\0';
 
     // Create JSON document.
     rapidjson::Document document;

--- a/engine/source/platformAndroid/AndroidEvents.h
+++ b/engine/source/platformAndroid/AndroidEvents.h
@@ -54,7 +54,7 @@ bool AndroidHandleMenuCommand(void* hiCommand);
 void AndroidSendTorqueEventToMain( U32 eventKind, void* userData = NULL );
 
 /// event type for alerts. The event class is an arbitrary val, it must not collide w/ kEventApp* .
-const U32 kEventClassTorque   = 'TORQ';
+const U32 kEventClassTorque   = ('T' * 0x1000000 + 'O' * 0x10000 + 'R' * 0x100 + 'Q'); //'TORQ';
 const U32 kEventTorqueAlert   = 1;
 const U32 kEventTorqueFadeInWindow = 2;
 const U32 kEventTorqueFadeOutWindow = 3;
@@ -63,7 +63,7 @@ const U32 kEventTorqueShowMenuBar = 5;
 const U32 kEventTorqueModalDialog = 6;
 const U32 kEventTorqueDrawMenuBar = 7;
 
-const U32 kEventParamTorqueData           = 'tDAT'; // typeVoidPtr void*
+const U32 kEventParamTorqueData           = ('t' * 0x1000000 + 'D' * 0x10000 + 'A' * 0x100 + 'T'); //'tDAT'; // typeVoidPtr void*
 //const U32 kEventParamTorqueSemaphorePtr   = 'tSEM'; // typeVoidPtr void*
 //const U32 kEventParamTorqueDialogRef      = 'tDRF'; // typeDialogRef DialogRef
 //const U32 kEventParamTorqueHitPtr         = 'tHIT'; // typeVoidPtr U32*
@@ -71,6 +71,6 @@ const U32 kEventParamTorqueData           = 'tDAT'; // typeVoidPtr void*
 
 
 // this command id is used for all dynamically created menus.
-const U32 kHICommandTorque = 'TORQ';
+const U32 kHICommandTorque = ('T' * 0x1000000 + 'O' * 0x10000 + 'R' * 0x100 + 'Q'); //'TORQ';
 
 #endif

--- a/engine/source/platformAndroid/AndroidProcessControl.cpp
+++ b/engine/source/platformAndroid/AndroidProcessControl.cpp
@@ -38,7 +38,7 @@ void Platform::postQuitMessage(const U32 in_quitVal)
 
 void Platform::debugBreak()
 {
-   Platform::outputDebugString((const char *)"\pDEBUG_BREAK!");
+   Platform::outputDebugString((const char *)"DEBUG_BREAK!");
 }
 
 void Platform::forceShutdown(S32 returnValue)

--- a/engine/source/string/stringBuffer.cc
+++ b/engine/source/string/stringBuffer.cc
@@ -384,7 +384,7 @@ void StringBuffer::getCopy(UTF16 *buff, const U32 buffSize) const
    AssertFatal(mBuffer.last() == 0, "StringBuffer::get UTF8 - not a null terminated string!");
    dMemcpy(buff, mBuffer.address(), sizeof(UTF16) * getMin(buffSize, (U32)mBuffer.size()));
    // ensure null termination.
-   buff[buffSize-1] = NULL;
+   buff[buffSize-1] = '\0';
 }
 
 UTF8* StringBuffer::createCopy8() const


### PR DESCRIPTION
This pull request fixes the following issues:
* Gradle build failure due to .cmd extension missing for ndk-build of which is required on Windows.
 * Simple fix by appending the extension when Windows is detected as the OS.
* Compiler errors due to several enum names being used as a namespace.
 * I know this is allowed with C++11, but it seems to not be enabled or available with current build-tools releases.
* Minor, but annoying compiler warnings.
