### PR TITLE
Update x86UNIX's OpenGLDevice to implement the abstract class

### DIFF
--- a/engine/source/platformX86UNIX/x86UNIXOGLVideo.cc
+++ b/engine/source/platformX86UNIX/x86UNIXOGLVideo.cc
@@ -489,6 +489,19 @@ bool OpenGLDevice::setGammaCorrection(F32 g)
 }
 
 //------------------------------------------------------------------------------
+bool OpenGLDevice::getVerticalSync()
+{
+   Con::printf("WARNING: OpenGLDevice::getVerticalSync is unimplemented %s %d\n", __FILE__, __LINE__);
+   return false;
+#if 0
+    if ( !gGLState.suppSwapInterval )
+        return( false );
+
+    return (qwglGetSwapIntervalEXT());
+#endif
+}
+
+//------------------------------------------------------------------------------
 bool OpenGLDevice::setVerticalSync( bool on )
 {
    Con::printf("WARNING: OpenGLDevice::setVerticalSync is unimplemented %s %d\n", __FILE__, __LINE__);

--- a/engine/source/platformX86UNIX/x86UNIXOGLVideo.h
+++ b/engine/source/platformX86UNIX/x86UNIXOGLVideo.h
@@ -42,7 +42,7 @@ class OpenGLDevice : public DisplayDevice
       OpenGLDevice();
       virtual ~OpenGLDevice();
 
-      void initDevice();
+      virtual void initDevice();
       bool activate( U32 width, U32 height, U32 bpp, bool fullScreen );
       void shutdown();
       void destroy();
@@ -51,6 +51,7 @@ class OpenGLDevice : public DisplayDevice
       const char* getDriverInfo();
       bool getGammaCorrection(F32 &g);
       bool setGammaCorrection(F32 g);
+      bool getVerticalSync();
       bool setVerticalSync( bool on );
       void loadResolutions();
 


### PR DESCRIPTION
* It looks like the platformX86UNIX OpenGLDevice was missing a required
  method. Added it back so it compiles, but with the same
  "unimplemented" message that setVerticalSync uses.