### PR TITLE
Fix building errors under Android Studio

### DIFF
--- a/engine/compilers/android-studio/app/src/main/jni/Android.mk
+++ b/engine/compilers/android-studio/app/src/main/jni/Android.mk
@@ -198,6 +198,7 @@ LOCAL_SRC_FILES :=  ../../../../../../lib/ljpeg/jcapimin.c \
                     ../../../../../../lib/libvorbis/vorbisfile.c \
                     ../../../../../../lib/libvorbis/window.c \
 					../../../../../../source/2d/assets/AnimationAsset.cc \
+					../../../../../../source/2d/assets/FontAsset.cc \
 					../../../../../../source/2d/assets/ImageAsset.cc \
 					../../../../../../source/2d/assets/ParticleAsset.cc \
 					../../../../../../source/2d/assets/ParticleAssetEmitter.cc \
@@ -227,7 +228,6 @@ LOCAL_SRC_FILES :=  ../../../../../../lib/ljpeg/jcapimin.c \
 					../../../../../../source/2d/gui/guiSpriteCtrl.cc \
 					../../../../../../source/2d/gui/SceneWindow.cc \
 					../../../../../../source/2d/sceneobject/CompositeSprite.cc \
-					../../../../../../source/2d/sceneobject/ImageFont.cc \
 					../../../../../../source/2d/sceneobject/ParticlePlayer.cc \
 					../../../../../../source/2d/sceneobject/SceneObject.cc \
 					../../../../../../source/2d/sceneobject/SceneObjectList.cc \
@@ -236,6 +236,7 @@ LOCAL_SRC_FILES :=  ../../../../../../lib/ljpeg/jcapimin.c \
 					../../../../../../source/2d/sceneobject/ShapeVector.cc \
 					../../../../../../source/2d/sceneobject/SkeletonObject.cc \
 					../../../../../../source/2d/sceneobject/Sprite.cc \
+					../../../../../../source/2d/sceneobject/TextSprite.cc \
 					../../../../../../source/2d/sceneobject/Trigger.cc \
 					../../../../../../source/2d/scene/ContactFilter.cc \
 					../../../../../../source/2d/scene/DebugDraw.cc \
@@ -260,6 +261,8 @@ LOCAL_SRC_FILES :=  ../../../../../../lib/ljpeg/jcapimin.c \
 					../../../../../../source/audio/AudioAsset.cc \
 					../../../../../../source/audio/audioBuffer.cc \
 					../../../../../../source/audio/vorbisStreamSource.cc \
+					../../../../../../source/bitmapFont/BitmapFont.cc \
+					../../../../../../source/bitmapFont/BitmapFontCharacter.cc \
 					../../../../../../source/Box2D/Collision/b2BroadPhase.cpp \
 					../../../../../../source/Box2D/Collision/b2CollideCircle.cpp \
 					../../../../../../source/Box2D/Collision/b2CollideEdge.cpp \
@@ -603,10 +606,12 @@ LOCAL_SRC_FILES :=  ../../../../../../lib/ljpeg/jcapimin.c \
 #					../../../../../../source/testing/unitTesting.cc
  
 ifeq ($(APP_OPTIM),debug)
-	LOCAL_CFLAGS := -DENABLE_CONSOLE_MSGS -D__ANDROID__ -DTORQUE_DEBUG -DTORQUE_OS_ANDROID -DGL_GLEXT_PROTOTYPES -O0 -fsigned-char   
+	LOCAL_CFLAGS := -DENABLE_CONSOLE_MSGS -D__ANDROID__ -DTORQUE_DEBUG -DTORQUE_OS_ANDROID -DGL_GLEXT_PROTOTYPES -O0 -fsigned-char
+	LOCAL_CPPFLAGS := -std=gnu++11 $(LOCAL_CFLAGS)
 else
-	LOCAL_CFLAGS := -DENABLE_CONSOLE_MSGS -D__ANDROID__ -DTORQUE_OS_ANDROID -DGL_GLEXT_PROTOTYPES -O3 -fsigned-char   
-endif				   
+	LOCAL_CFLAGS := -DENABLE_CONSOLE_MSGS -D__ANDROID__ -DTORQUE_OS_ANDROID -DGL_GLEXT_PROTOTYPES -O3 -fsigned-char
+	LOCAL_CPPFLAGS := -std=gnu++11 $(LOCAL_CFLAGS)
+endif
 LOCAL_LDLIBS    := -llog -landroid -lEGL -lGLESv1_CM -lz -lOpenSLES -L../../../../../../lib/openal/Android/$(TARGET_ARCH_ABI)
 LOCAL_STATIC_LIBRARIES := android_native_app_glue freetype-prebuilt
 LOCAL_SHARED_LIBRARIES := libopenal-prebuilt

--- a/engine/source/2d/sceneobject/TextSprite.cc
+++ b/engine/source/2d/sceneobject/TextSprite.cc
@@ -780,7 +780,7 @@ void TextSprite::setCharacterBlendColor(const U32 charNum, const ColorF color)
    }
    else
    {
-      mCharInfo.emplace(charNum, BitmapFontCharacterInfo(color));
+      mCharInfo[charNum] = BitmapFontCharacterInfo(color);
    }
 }
 
@@ -826,7 +826,7 @@ void TextSprite::setCharacterScale(const U32 charNum, const F32 scaleX, const F3
 {
    if (mCharInfo.find(charNum) == mCharInfo.end())
    {
-      mCharInfo.emplace(charNum, BitmapFontCharacterInfo());
+      mCharInfo[charNum] = BitmapFontCharacterInfo();
    }
    mCharInfo[charNum].mScaleX = scaleX;
    mCharInfo[charNum].mScaleY = scaleY;
@@ -873,7 +873,7 @@ void TextSprite::setCharacterOffset(const U32 charNum, const F32 offsetX, const 
 {
    if (mCharInfo.find(charNum) == mCharInfo.end())
    {
-      mCharInfo.emplace(charNum, BitmapFontCharacterInfo());
+      mCharInfo[charNum] = BitmapFontCharacterInfo();
    }
    mCharInfo[charNum].mOffsetX = offsetX;
    mCharInfo[charNum].mOffsetY = offsetY;

--- a/engine/source/bitmapFont/BitmapFont.cc
+++ b/engine/source/bitmapFont/BitmapFont.cc
@@ -188,7 +188,7 @@ namespace font
             }
             ci.mCharID = CharID;
             ci.ProcessCharacter(mWidth, mHeight);
-            mChar.emplace(CharID, ci);
+            mChar[CharID] = ci;
          }
          else if (dStrcmp(Read, "kerning") == 0 && dStrcmp(Read, "kernings") != 0)
          {

--- a/engine/source/platformAndroid/AndroidOGLVideo.cpp
+++ b/engine/source/platformAndroid/AndroidOGLVideo.cpp
@@ -39,6 +39,8 @@
 #include "graphics/dgl.h"
 #include "debug/profiler.h"
 #include "platformAndroid/T2DActivity.h"
+#include "AndroidOGLVideo.h"
+#include "../platform/platformVideo_ScriptBinding.h"
 
 //Luma: Tap support
 extern void createMouseTapEvent(S32 nbrTaps, S32 x, S32 y);
@@ -255,6 +257,12 @@ bool OpenGLDevice::getGammaCorrection(F32 &g)
 
 //------------------------------------------------------------------------------
 bool OpenGLDevice::setGammaCorrection(F32 g)
+{
+    return true;
+}
+
+//------------------------------------------------------------------------------
+bool OpenGLDevice::getVerticalSync()
 {
     return true;
 }

--- a/engine/source/platformAndroid/AndroidOGLVideo.cpp
+++ b/engine/source/platformAndroid/AndroidOGLVideo.cpp
@@ -39,8 +39,6 @@
 #include "graphics/dgl.h"
 #include "debug/profiler.h"
 #include "platformAndroid/T2DActivity.h"
-#include "AndroidOGLVideo.h"
-#include "../platform/platformVideo_ScriptBinding.h"
 
 //Luma: Tap support
 extern void createMouseTapEvent(S32 nbrTaps, S32 x, S32 y);

--- a/engine/source/platformAndroid/AndroidOGLVideo.h
+++ b/engine/source/platformAndroid/AndroidOGLVideo.h
@@ -51,6 +51,7 @@ public:
     const char* getDriverInfo();
     bool getGammaCorrection(F32 &g);
     bool setGammaCorrection(F32 g);
+    bool getVerticalSync();
     bool setVerticalSync( bool on );
 };
 


### PR DESCRIPTION
This pull request:
* Updates App Android.mk makefile to support PR #326 changes.
* Updates Android OGLVideo to support PR #323 changes.
* Workaround for Android stdlibc++ lacking `std::map::emplace()` support by replacing them with implicit `std::map::insert()` usage via `map[key] = value`.

Modified and tested with Android Studio v1.5.1 and NDK r10e, the latest versions as of this posting.
