### PR TITLE
Write Defaults Fix

### DIFF
--- a/engine/source/sim/simObject.cc
+++ b/engine/source/sim/simObject.cc
@@ -622,11 +622,8 @@ const char *SimObject::getPrefixedDataField(StringTableEntry fieldName, const ch
     // Fetch field value.
     const char* pFieldValue = getDataField( fieldName, array );
 
-    // Sanity.
-    AssertFatal( pFieldValue != NULL, "Field value cannot be NULL." );
-
     // Return without the prefix if there's no value.
-    if ( *pFieldValue == 0 )
+    if ( pFieldValue == NULL || *pFieldValue == 0 )
         return StringTable->EmptyString;
 
     // Fetch the field prefix.


### PR DESCRIPTION
This corrects long-standing error #79 that causes the game to crash when writing the defaults in taml.