### PR TITLE
CompositeSprite LocalPosition Bug

### DIFF
--- a/engine/source/2d/sceneobject/CompositeSprite.h
+++ b/engine/source/2d/sceneobject/CompositeSprite.h
@@ -66,6 +66,8 @@ public:
     virtual void integrateObject( const F32 totalTime, const F32 elapsedTime, DebugStats* pDebugStats );
     virtual void interpolateObject( const F32 timeDelta );
 
+    virtual inline void setSpatialDirty(void) { mSpatialDirty = true; }
+
     virtual bool canPrepareRender( void ) const { return true; }
     virtual bool shouldRender( void ) const { return true; }
     virtual void scenePrepareRender( const SceneRenderState* pSceneRenderState, SceneRenderQueue* pSceneRenderQueue );    

--- a/engine/source/2d/sceneobject/CompositeSprite_ScriptBinding.h
+++ b/engine/source/2d/sceneobject/CompositeSprite_ScriptBinding.h
@@ -562,6 +562,7 @@ ConsoleMethodWithDocs(CompositeSprite, setSpriteLocalPosition, ConsoleVoid, 3, 4
     }
 
     object->setSpriteLocalPosition( localPosition );
+    object->setSpatialDirty();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This fixes a bug with the CompositeSprite.  When setting the local position of a sprite within a CompositeSprite the SpatialDirty flag needs to be set to true for the Sprite to be redrawn at the new position.  The occurs when the CompositeSprite is moving, rotating, or if the CompositeSprite automatically changes size because of the sprite relocation.  However, if the CompositeSprite is still, the inner sprite will not be redrawn at the new location.  This change fixes that simply by setting the SpatialDirty flag to true when the inner sprite is moved.