### PR TITLE
TextSprite Zero Size Bug

### DIFF
--- a/engine/source/2d/sceneobject/TextSprite.cc
+++ b/engine/source/2d/sceneobject/TextSprite.cc
@@ -645,7 +645,7 @@ void TextSprite::CalculateSpatials(F32 ratio)
             wordEndLength = length - getCursorAdvance(bmChar, prevCharID, ratio);
          }
 
-         if (length > mSize.x && wordEnd > start)
+         if (length > mSize.x && wordEnd > start && start != -1)
          {
             mLine.back().mEnd = wordEnd;
             U32 endCharID = mText.getChar(wordEnd);


### PR DESCRIPTION
Fixes error #349, a bug which causes an endless loop in the game engine when a
TextSprite set to wrap has a width that is less than the length of a
space.  An additional test is made to ensure that we have started a new
word in the wrapping algorithm.