### PR TITLE
CompositeSprite Animation Bug

### DIFF
--- a/engine/source/2d/core/SpriteBatch.cc
+++ b/engine/source/2d/core/SpriteBatch.cc
@@ -1239,6 +1239,18 @@ SpriteBatchItem* SpriteBatch::createSprite( const SpriteBatchItem::LogicalPositi
 
 //------------------------------------------------------------------------------
 
+void SpriteBatch::integrateSprites(const F32 totalTime, const F32 elapsedTime, DebugStats* pDebugStats)
+{
+   //process the elapsed time for all sprites
+   for (typeSpriteBatchHash::iterator spriteItr = mSprites.begin(); spriteItr != mSprites.end(); ++spriteItr)
+   {
+      // Update image frame provider.
+      spriteItr->value->ImageFrameProvider::update(elapsedTime);
+   }
+}
+
+//------------------------------------------------------------------------------
+
 void SpriteBatch::setBatchTransform( const b2Transform& batchTransform )
 {
     // Update world transform.

--- a/engine/source/2d/core/SpriteBatch.h
+++ b/engine/source/2d/core/SpriteBatch.h
@@ -198,6 +198,8 @@ protected:
 
     virtual SpriteBatchItem* createSprite( const SpriteBatchItem::LogicalPosition& logicalPosition );
 
+    void integrateSprites(const F32 totalTime, const F32 elapsedTime, DebugStats* pDebugStats);
+
     void setBatchTransform( const b2Transform& batchTransform );
     void updateLocalExtents( void );
 

--- a/engine/source/2d/core/SpriteBatchItem.cc
+++ b/engine/source/2d/core/SpriteBatchItem.cc
@@ -133,8 +133,8 @@ void SpriteBatchItem::resetState( void )
 
     mUserData = NULL;
 
-    // Require self ticking.
-    mSelfTick = true;
+    // Only animates if the scene is not paused.
+    mSelfTick = false;
 }
 
 //------------------------------------------------------------------------------

--- a/engine/source/2d/sceneobject/CompositeSprite.cc
+++ b/engine/source/2d/sceneobject/CompositeSprite.cc
@@ -165,6 +165,8 @@ void CompositeSprite::integrateObject( const F32 totalTime, const F32 elapsedTim
     // Call Parent.
     Parent::integrateObject( totalTime, elapsedTime, pDebugStats );
 
+    integrateSprites(totalTime, elapsedTime, pDebugStats);
+
     // Finish if the spatials are NOT dirty.
     if ( !getSpatialDirty() )
         return;


### PR DESCRIPTION
Fixes issues #369. Previously, CompositeSprites would continue to animate even when the
scene was paused.  This is because the ImageFrameProvider for each
sprite would receive the tick event and process it independently of the
Scene.  I turned this off.  Now when the Scene processes a
CompositeSprite, each sprite in the composite is given the chance to
advance its animation.  If the Scene is paused, then there is no
animation.