### PR TITLE
wrong delete operator in guiGridCtrl.cc

### DIFF
--- a/engine/source/gui/containers/guiGridCtrl.cc
+++ b/engine/source/gui/containers/guiGridCtrl.cc
@@ -294,7 +294,7 @@ void GuiGridControl::AdjustGridItems(S32 size, Vector<StringTableEntry>& strItem
 			char* tmp = new char[len-1];
 			dStrncpy(tmp, str, len-1);
 			int perc = dAtoi(tmp);
-			delete tmp;
+			delete[] tmp;
 
 			GridItem gi;
 			gi.IsAbsolute = false;


### PR DESCRIPTION
this line was flagged by the android compiler. the suggested fix doesn't break any of my builds, but test before merging.