### PR TITLE
GUI Tooltip Timer Fix

### DIFF
--- a/engine/source/gui/guiCanvas.cc
+++ b/engine/source/gui/guiCanvas.cc
@@ -594,8 +594,12 @@ void GuiCanvas::findMouseControl(const GuiEvent &event)
    GuiControl *controlHit = findHitControl(event.mousePoint);
    if(controlHit != static_cast<GuiControl*>(mMouseControl))
    {
-      if(bool(mMouseControl))
+      if (bool(mMouseControl))
+      {
          mMouseControl->onMouseLeave(event);
+         hoverControlStart = Platform::getRealMilliseconds();
+         hoverPositionSet = false;
+      }
       mMouseControl = controlHit;
       mMouseControl->onMouseEnter(event);
    }


### PR DESCRIPTION
This corrects issue #387 by reseting the tooltip timer when the mouse
leaves a mouse element.  This fix was suggested by ParodyGames on
Github.