### PR TITLE
Fix compiling under Android Studio

### DIFF
--- a/engine/compilers/android-studio/app/app.iml
+++ b/engine/compilers/android-studio/app/app.iml
@@ -9,7 +9,6 @@
     <facet type="android" name="Android">
       <configuration>
         <option name="SELECTED_BUILD_VARIANT" value="debug" />
-        <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
         <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
         <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
         <afterSyncTasks>
@@ -28,30 +27,32 @@
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/build/intermediates/classes/debug" />
     <output-test url="file://$MODULE_DIR$/build/intermediates/classes/test/debug" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/debug" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/debug" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/androidTest/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/androidTest/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/androidTest/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/androidTest/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/androidTest/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/androidTest/debug" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/test/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/assets" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/aidl" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/shaders" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/res" type="java-test-resource" />
@@ -59,44 +60,68 @@
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/assets" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/aidl" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/assets" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/game" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/aidl" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/build-info" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/check-manifest" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-safeguard" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-classes" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-runtime-classes" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-verifier" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-resources" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javaPrecompile" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/lint" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/ndkBuild" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/prebuild" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/reload-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/split-apk" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/splits-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/tmp" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/transforms" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />

--- a/engine/compilers/android-studio/app/build.gradle
+++ b/engine/compilers/android-studio/app/build.gradle
@@ -1,33 +1,30 @@
 apply plugin: 'com.android.application'
-
-
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.1"
-
-    externalNativeBuild{
-        ndkBuild{
+    buildToolsVersion '26.0.2'
+    externalNativeBuild {
+        ndkBuild {
             path './src/main/jni/Android.mk'
         }
     }
     defaultConfig {
         applicationId "com.garagegames.torque2d"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 25
 
         sourceSets.main {
-            assets.srcDirs=[
+            assets.srcDirs = [
                     'src/main/assets',
                     'src/main/game'
             ]
 
             ndk {
-                     abiFilters 'x86', 'x86_64', 'armeabi-v7a'
+                abiFilters 'x86', 'x86_64', 'armeabi-v7a'
             }
         }
 
-        task copyGame(type: Copy, description: 'Copy torque scripts and modules'){
-            from('../../../../'){
+        task copyGame(type: Copy, description: 'Copy torque scripts and modules') {
+            from('../../../../') {
                 include '**'
                 exclude 'engine/**'
                 exclude 'tools/**'
@@ -46,7 +43,7 @@ android {
 
         }
 
-        task wipeGame(type: Delete, description: 'Wipe android-specific copy of torque scripts and modules'){
+        task wipeGame(type: Delete, description: 'Wipe android-specific copy of torque scripts and modules') {
             delete 'src/main/game/'
         }
 
@@ -58,11 +55,14 @@ android {
 
 
     }
-
     buildTypes {
         release {
             minifyEnabled false
         }
     }
+    productFlavors {
+    }
+}
 
+dependencies {
 }

--- a/engine/compilers/android-studio/app/src/main/java/com/garagegames/torque2d/MyNativeActivity.java
+++ b/engine/compilers/android-studio/app/src/main/java/com/garagegames/torque2d/MyNativeActivity.java
@@ -2,6 +2,8 @@ package com.garagegames.torque2d;
 
 import android.app.NativeActivity;
 import android.view.View;
+import android.os.Bundle;
+
 
 public class MyNativeActivity extends NativeActivity {
   static {

--- a/engine/compilers/android-studio/app/src/main/jni/Android.mk
+++ b/engine/compilers/android-studio/app/src/main/jni/Android.mk
@@ -610,10 +610,10 @@ LOCAL_SRC_FILES :=  ../../../../../../lib/ljpeg/jcapimin.c \
  
 ifeq ($(APP_OPTIM),debug)
 	LOCAL_CFLAGS := -DENABLE_CONSOLE_MSGS -D__ANDROID__ -DTORQUE_DEBUG -DTORQUE_OS_ANDROID -DGL_GLEXT_PROTOTYPES -O0 -fsigned-char
-	LOCAL_CPPFLAGS := -std=gnu++11 $(LOCAL_CFLAGS)
+	LOCAL_CPPFLAGS := -std=gnu++11 -frtti $(LOCAL_CFLAGS)
 else
 	LOCAL_CFLAGS := -DENABLE_CONSOLE_MSGS -D__ANDROID__ -DTORQUE_OS_ANDROID -DGL_GLEXT_PROTOTYPES -O3 -fsigned-char
-	LOCAL_CPPFLAGS := -std=gnu++11 $(LOCAL_CFLAGS)
+	LOCAL_CPPFLAGS := -std=gnu++11 -frtti $(LOCAL_CFLAGS)
 endif
 LOCAL_LDLIBS    := -llog -landroid -lEGL -lGLESv1_CM -lz -lOpenSLES -L../../../../../../lib/openal/Android/$(TARGET_ARCH_ABI)
 LOCAL_STATIC_LIBRARIES := freetype-prebuilt

--- a/engine/compilers/android-studio/app/src/main/jni/Application.mk
+++ b/engine/compilers/android-studio/app/src/main/jni/Application.mk
@@ -1,4 +1,4 @@
 APP_PLATFORM := android-16
-APP_STL := stlport_static
+APP_STL := c++_static
 APP_OPTIM := release
 APP_ABI   := armeabi-v7a x86 x86_64

--- a/engine/compilers/android-studio/build.gradle
+++ b/engine/compilers/android-studio/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
     }
 }
 

--- a/engine/compilers/android-studio/gradle/wrapper/gradle-wrapper.properties
+++ b/engine/compilers/android-studio/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Aug 06 13:15:40 EDT 2016
+#Sun Feb 04 22:37:25 CST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/engine/source/console/consoleDoc.cc
+++ b/engine/source/console/consoleDoc.cc
@@ -278,7 +278,7 @@ void Namespace::printNamespaceEntries(Namespace * g, bool dumpScript, bool dumpE
          }
 
          // Finally, see if they did it foo(*) style.
-         char* func_pos = dStrstr(use, funcName);
+         const char* func_pos = dStrstr(use, funcName);
          if((func_pos) && (func_pos < bgn) && (end > bgn))
          {
             U32 len = (U32)(end - bgn - 1);

--- a/engine/source/console/output_ScriptBinding.h
+++ b/engine/source/console/output_ScriptBinding.h
@@ -181,7 +181,7 @@ ConsoleFunctionWithDocs(quitWithErrorMessage, ConsoleVoid, 2, 2, (msg string))
 ConsoleFunctionWithDocs( gotoWebPage, ConsoleVoid, 2, 2, ( address ))
 {
    TORQUE_UNUSED( argc );
-   char* protocolSep = dStrstr(argv[1],"://");
+   const char* protocolSep = dStrstr(argv[1],"://");
 
    if( protocolSep != NULL )
    {

--- a/engine/source/delegates/delegateSignal.h
+++ b/engine/source/delegates/delegateSignal.h
@@ -20,8 +20,8 @@
 // IN THE SOFTWARE.
 //-----------------------------------------------------------------------------
 
-#ifndef _SIGNAL_H_
-#define _SIGNAL_H_
+#ifndef _DELEGATESIGNAL_H_
+#define _DELEGATESIGNAL_H_
 
 #ifndef _UTIL_DELEGATE_H_
 #include "delegates/delegate.h"
@@ -663,4 +663,4 @@ class Signal<void(A,B,C,D,E,F,G,H,I,J)> : public SignalBaseT<void(A,B,C,D,E,F,G,
       }
 };
 
-#endif // _SIGNAL_H_
+#endif // _DELEGATESIGNAL_H_

--- a/engine/source/graphics/dgl_ScriptBinding.h
+++ b/engine/source/graphics/dgl_ScriptBinding.h
@@ -95,7 +95,7 @@ ConsoleFunctionWithDocs(png2jpg, ConsoleInt, 2, 3, ( pngFilename, [quality ]? ))
    {
       char * buf = new char[dStrlen(bmpname)+32];
       dStrcpy(buf,bmpname);
-      char * pos = dStrstr((const char*)buf,".png");
+      char * pos = dStrstr(buf,".png");
       if (!pos)
          pos = buf + dStrlen(buf);
       dStrcpy(pos,".jpg");
@@ -105,7 +105,7 @@ ConsoleFunctionWithDocs(png2jpg, ConsoleInt, 2, 3, ( pngFilename, [quality ]? ))
    {
       char * buf = new char[dStrlen(bmpname)+32];
       dStrcpy(buf,bmpname);
-      char * pos = dStrstr((const char*)buf,".png");
+      char * pos = dStrstr(buf,".png");
       if (!pos)
          pos = buf + dStrlen(buf);
       dStrcpy(pos,".alpha.jpg");

--- a/engine/source/platform/platformNet.cpp
+++ b/engine/source/platform/platformNet.cpp
@@ -259,7 +259,7 @@ namespace PlatformNetState
 
    struct addrinfo* pickAddressByProtocol(struct addrinfo* addr, int protocol)
    {
-      for (addr; addr != NULL; addr = addr->ai_next)
+      for (; addr != NULL; addr = addr->ai_next)
       {
          if (addr->ai_family == protocol)
             return addr;
@@ -1686,7 +1686,7 @@ Net::Error Net::send(NetSocket handleFd, const U8 *buffer, S32 bufferSize, S32 *
 
    if (outBytesWritten)
    {
-      *outBytesWritten = outBytesWritten < 0 ? 0 : bytesWritten;
+      *outBytesWritten = outBytesWritten < (void *)0 ? 0 : bytesWritten;
    }
 
    return PlatformNetState::getLastError();

--- a/engine/source/platform/platformString.h
+++ b/engine/source/platform/platformString.h
@@ -63,8 +63,8 @@ extern char* dStrrchr(char *str, int c);
 extern const char* dStrrchr(const char *str, int c);
 extern U32 dStrspn(const char *str, const char *set);
 extern U32 dStrcspn(const char *str, const char *set);
-extern char* dStrstr(char *str1, char *str2);
-extern char* dStrstr(const char *str1, const char *str2);
+extern char* dStrstr(char *str1, const char *str2);
+extern const char* dStrstr(const char *str1, const char *str2);
 
 extern char* dStrtok(char *str, const char *sep);
 

--- a/engine/source/platformAndroid/AndroidInput.cpp
+++ b/engine/source/platformAndroid/AndroidInput.cpp
@@ -411,7 +411,7 @@ const char* Platform::getClipboard()
 //-----------------------------------------------------------------------------
 bool Platform::setClipboard(const char *text)
 {
-	return NULL;//no clipboard on Android
+	return false;//no clipboard on Android
 }
 
 #pragma mark ---- Cursor Functions ----

--- a/engine/source/platformAndroid/AndroidStrings.cpp
+++ b/engine/source/platformAndroid/AndroidStrings.cpp
@@ -258,12 +258,12 @@ U32 dStrcspn(const char *str, const char *set)
 }   
 
 
-char* dStrstr(char *str1, char *str2)
+char* dStrstr(char *str1, const char *str2)
 {
    return strstr(str1,str2);
 }
 
-char* dStrstr(const char *str1, const char *str2)
+const char* dStrstr(const char *str1, const char *str2)
 {
    return strstr(str1,str2);
 }   

--- a/engine/source/platformAndroid/T2DActivity.cpp
+++ b/engine/source/platformAndroid/T2DActivity.cpp
@@ -2678,7 +2678,7 @@ char* _AndroidLoadInternalFile(const char* fn, U32 *size)
 
 	lResult=lJavaVM->AttachCurrentThread(&lJNIEnv, &lJavaVMAttachArgs);
 	if (lResult == JNI_ERR) {
-		return "";
+		return NULL;
 	}
 
 	// Retrieves NativeActivity.

--- a/engine/source/platformAndroid/android_native_app_glue.c
+++ b/engine/source/platformAndroid/android_native_app_glue.c
@@ -17,10 +17,12 @@
 
 #include <jni.h>
 
+#include <stdlib.h>
 #include <errno.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/resource.h>
+
 
 #include "android_native_app_glue.h"
 #include <android/log.h>

--- a/engine/source/platformEmscripten/EmscriptenStrings.cpp
+++ b/engine/source/platformEmscripten/EmscriptenStrings.cpp
@@ -249,12 +249,12 @@ dsize_t dStrcspn(const char *str, const char *set)
 }   
 
 
-char* dStrstr(char *str1, char *str2)
+char* dStrstr(char *str1, const char *str2)
 {
    return strstr(str1,str2);
 }
 
-char* dStrstr(const char *str1, const char *str2)
+const char* dStrstr(const char *str1, const char *str2)
 {
    return strstr(str1,str2);
 }   

--- a/engine/source/platformOSX/osxString.mm
+++ b/engine/source/platformOSX/osxString.mm
@@ -319,14 +319,14 @@ U32 dStrcspn(const char *str, const char *set)
 
 //-----------------------------------------------------------------------------
 
-char* dStrstr(char *str1, char *str2)
+char* dStrstr(char *str1, const char *str2)
 {
     return strstr(str1, str2);
 }
 
 //-----------------------------------------------------------------------------
 
-char* dStrstr(const char *str1, const char *str2)
+const char* dStrstr(const char *str1, const char *str2)
 {
     return strstr(str1, str2);
 }

--- a/engine/source/platformWin32/winStrings.cc
+++ b/engine/source/platformWin32/winStrings.cc
@@ -247,12 +247,12 @@ U32 dStrcspn(const char *str, const char *set)
 }
 
 
-char* dStrstr(char *str1, char *str2)
+char* dStrstr(char *str1, const char *str2)
 {
    return strstr(str1,str2);
 }
 
-char* dStrstr(const char *str1, const char *str2)
+const char* dStrstr(const char *str1, const char *str2)
 {
    return strstr((char *)str1,str2);
 }

--- a/engine/source/platformX86UNIX/x86UNIXStrings.cc
+++ b/engine/source/platformX86UNIX/x86UNIXStrings.cc
@@ -295,12 +295,12 @@ U32 dStrcspn(const char *str, const char *set)
 }   
 
 
-char* dStrstr(char *str1, char *str2)
+char* dStrstr(char *str1, const char *str2)
 {
    return strstr(str1,str2);
 }
 
-char* dStrstr(const char *str1, const char *str2)
+const char* dStrstr(const char *str1, const char *str2)
 {
    return strstr((char *)str1,str2);
 }

--- a/engine/source/platformiOS/iOSStrings.mm
+++ b/engine/source/platformiOS/iOSStrings.mm
@@ -259,12 +259,12 @@ U32 dStrcspn(const char *str, const char *set)
 }   
 
 
-char* dStrstr(char *str1, char *str2)
+char* dStrstr(char *str1, const char *str2)
 {
    return strstr(str1,str2);
 }
 
-char* dStrstr(const char *str1, const char *str2)
+const char* dStrstr(const char *str1, const char *str2)
 {
    return strstr(str1,str2);
 }   


### PR DESCRIPTION
This PR fixes building and running under current Android Studio IDE stable release along with current Gradle build system.

Important Highlights:
- Changed APP_STL to `c++_static` as `stlport_static` is depreciated and broken in latest NDK anyway.
- Current compiler has RTTI disabled by default so C++ compiler flags updated to explicitly enable RTTI.
- Minimum SDK version changed from 16 -> 19.
- Minimum build tools is now 26.0.2 as required for current Android SDK.
- Torque's `strstr` variant wasn't standard library compliant and has been fixed for all platforms that Torque 2D compiles for and runs on. Was explicitly corrected for Android Studio because current compiler refuses to allow old/incorrect usages.
- All Android platform build specific warnings have been fixed.
