### PR TITLE
Fix general compiler warnings

### DIFF
--- a/engine/source/2d/core/SpriteBatch.cc
+++ b/engine/source/2d/core/SpriteBatch.cc
@@ -533,7 +533,7 @@ U32 SpriteBatch::getSpriteImageFrame( void ) const
 {
     // Finish if a sprite is not selected.
     if ( !checkSpriteSelected() )
-        return NULL;
+        return 0;
 
     // Get image frame.
     return mSelectedSprite->getImageFrame();
@@ -611,7 +611,7 @@ U32 SpriteBatch::getSpriteAnimationFrame(void) const
 {
 	// Finish if a sprite is not selected.
 	if (!checkSpriteSelected())
-		return NULL;
+		return 0;
 
 	// Get image frame.
 	return mSelectedSprite->getAnimationFrame();

--- a/engine/source/2d/core/Vector2_ScriptBinding.h
+++ b/engine/source/2d/core/Vector2_ScriptBinding.h
@@ -202,7 +202,7 @@ ConsoleFunctionWithDocs( Vector2Compare, ConsoleBool, 3, 4, (Vector2 p1, Vector2
     if (Utility::mGetStringElementCount(argv[1]) < 2 ||Utility::mGetStringElementCount(argv[2]) < 2 )
     {
         Con::warnf("Vector2Compare() - Invalid number of parameters!");
-        return NULL;
+        return false;
     }
 
     Vector2 p1( argv[1] );
@@ -228,7 +228,7 @@ ConsoleFunctionWithDocs( Vector2Distance, ConsoleFloat, 3, 3, (Vector2 p1, Vecto
     if (Utility::mGetStringElementCount(argv[1]) < 2 ||Utility::mGetStringElementCount(argv[2]) < 2 )
     {
         Con::warnf("Vector2Distance() - Invalid number of parameters!");
-        return NULL;
+        return false;
     }
 
     Vector2 p1( argv[1] );
@@ -247,7 +247,7 @@ ConsoleFunctionWithDocs( Vector2AngleBetween, ConsoleFloat, 3, 3, (Vector2 v1, V
     if (Utility::mGetStringElementCount(argv[1]) < 2 ||Utility::mGetStringElementCount(argv[2]) < 2 )
     {
         Con::warnf("t2dAngleBetween() - Invalid number of parameters!");
-        return NULL;
+        return false;
     }
 
     Vector2 v1( argv[1] );
@@ -269,7 +269,7 @@ ConsoleFunctionWithDocs( Vector2AngleToPoint, ConsoleFloat, 3, 3, (Vector2 p1, V
     if (Utility::mGetStringElementCount(argv[1]) < 2 ||Utility::mGetStringElementCount(argv[2]) < 2 )
     {
         Con::warnf("t2dAngleToPoint() - Invalid number of parameters!");
-        return NULL;
+        return false;
     }
 
     Vector2 p1( argv[1] );

--- a/engine/source/2d/sceneobject/SceneObject.cc
+++ b/engine/source/2d/sceneobject/SceneObject.cc
@@ -293,35 +293,35 @@ void SceneObject::initPersistFields()
     addProtectedField("Size", TypeVector2, Offset( mSize, SceneObject), &setSize, &defaultProtectedGetFn, &writeSize, "");
 
     /// Position / Angle.
-    addProtectedField("Position", TypeVector2, NULL, &setPosition, &getPosition, &writePosition, "");
-    addProtectedField("Angle", TypeF32, NULL, &setAngle, &getAngle, &writeAngle, "");
-    addProtectedField("FixedAngle", TypeBool, NULL, &setFixedAngle, &getFixedAngle, &writeFixedAngle, "");
+    addProtectedField("Position", TypeVector2, 0, &setPosition, &getPosition, &writePosition, "");
+    addProtectedField("Angle", TypeF32, 0, &setAngle, &getAngle, &writeAngle, "");
+    addProtectedField("FixedAngle", TypeBool, 0, &setFixedAngle, &getFixedAngle, &writeFixedAngle, "");
 
     /// Body.
-    addProtectedField("BodyType", TypeEnum, NULL, &setBodyType, &getBodyType, &writeBodyType, 1, &bodyTypeTable, "" );
-    addProtectedField("Active", TypeBool, NULL, &setActive, &getActive, &writeActive, "" );
-    addProtectedField("Awake", TypeBool, NULL, &setAwake, &getAwake, &writeAwake, "" );
-    addProtectedField("Bullet", TypeBool, NULL, &setBullet, &getBullet, &writeBullet, "" );
-    addProtectedField("SleepingAllowed", TypeBool, NULL, &setSleepingAllowed, &getSleepingAllowed, &writeSleepingAllowed, "" );
+    addProtectedField("BodyType", TypeEnum, 0, &setBodyType, &getBodyType, &writeBodyType, 1, &bodyTypeTable, "" );
+    addProtectedField("Active", TypeBool, 0, &setActive, &getActive, &writeActive, "" );
+    addProtectedField("Awake", TypeBool, 0, &setAwake, &getAwake, &writeAwake, "" );
+    addProtectedField("Bullet", TypeBool, 0, &setBullet, &getBullet, &writeBullet, "" );
+    addProtectedField("SleepingAllowed", TypeBool, 0, &setSleepingAllowed, &getSleepingAllowed, &writeSleepingAllowed, "" );
 
     /// Collision control.
     addProtectedField("CollisionGroups", TypeS32, Offset(mCollisionGroupMask, SceneObject), &setCollisionGroups, &getCollisionGroups, &writeCollisionGroups, "");
     addProtectedField("CollisionLayers", TypeS32, Offset(mCollisionLayerMask, SceneObject), &setCollisionLayers, &getCollisionLayers, &writeCollisionLayers, "");
     addField("CollisionSuppress", TypeBool, Offset(mCollisionSuppress, SceneObject), &writeCollisionSuppress, "");
     addField("CollisionOneWay", TypeBool, Offset(mCollisionOneWay, SceneObject), &writeCollisionOneWay, "");
-    addProtectedField("GatherContacts", TypeBool, NULL, &setGatherContacts, &defaultProtectedGetFn, &writeGatherContacts, "");
+    addProtectedField("GatherContacts", TypeBool, 0, &setGatherContacts, &defaultProtectedGetFn, &writeGatherContacts, "");
     addProtectedField("DefaultDensity", TypeF32, Offset( mDefaultFixture.density, SceneObject), &setDefaultDensity, &defaultProtectedGetFn, &writeDefaultDensity, "");
     addProtectedField("DefaultFriction", TypeF32, Offset( mDefaultFixture.friction, SceneObject), &setDefaultFriction, &defaultProtectedGetFn, &writeDefaultFriction, "");
     addProtectedField("DefaultRestitution", TypeF32, Offset( mDefaultFixture.restitution, SceneObject), &setDefaultRestitution, &defaultProtectedGetFn, &writeDefaultRestitution, "");
 
     /// Velocities.
-    addProtectedField("LinearVelocity", TypeVector2, NULL, &setLinearVelocity, &getLinearVelocity, &writeLinearVelocity, "");
-    addProtectedField("AngularVelocity", TypeF32, NULL, &setAngularVelocity, &getAngularVelocity, &writeAngularVelocity, "");
-    addProtectedField("LinearDamping", TypeF32, NULL, &setLinearDamping, &getLinearDamping, &writeLinearDamping, "");
-    addProtectedField("AngularDamping", TypeF32, NULL, &setAngularDamping, &getAngularDamping, &writeAngularDamping, "");
+    addProtectedField("LinearVelocity", TypeVector2, 0, &setLinearVelocity, &getLinearVelocity, &writeLinearVelocity, "");
+    addProtectedField("AngularVelocity", TypeF32, 0, &setAngularVelocity, &getAngularVelocity, &writeAngularVelocity, "");
+    addProtectedField("LinearDamping", TypeF32, 0, &setLinearDamping, &getLinearDamping, &writeLinearDamping, "");
+    addProtectedField("AngularDamping", TypeF32, 0, &setAngularDamping, &getAngularDamping, &writeAngularDamping, "");
 
     /// Gravity scaling.
-    addProtectedField("GravityScale", TypeF32, NULL, &setGravityScale, &getGravityScale, &writeGravityScale, "");
+    addProtectedField("GravityScale", TypeF32, 0, &setGravityScale, &getGravityScale, &writeGravityScale, "");
 
     /// Render visibility.
     addField("Visible", TypeBool, Offset(mVisible, SceneObject), &writeVisible, "");

--- a/engine/source/2d/sceneobject/SceneObject_ScriptBinding.h
+++ b/engine/source/2d/sceneobject/SceneObject_ScriptBinding.h
@@ -2541,7 +2541,7 @@ ConsoleMethodWithDocs(SceneObject, getCollisionShapeArea, ConsoleFloat, 3, 3, (i
     if ( shapeIndex >= shapeCount )
     {
         Con::warnf("SceneObject::getCollisionShapeArea() - Invalid shape index of %d.", shapeIndex);
-        return NULL;
+        return 0.0f;
     }
 
     // Calculate area if the shape type is circle

--- a/engine/source/2d/sceneobject/SkeletonObject.cc
+++ b/engine/source/2d/sceneobject/SkeletonObject.cc
@@ -88,8 +88,8 @@ void SkeletonObject::initPersistFields()
     addProtectedField("Asset", TypeSkeletonAssetPtr, Offset(mSkeletonAsset, SkeletonObject), &setSkeletonAsset, &getSkeletonAsset, &writeSkeletonAsset, "The skeleton asset ID used for the skeleton.");
     addProtectedField("AnimationName", TypeString, Offset(mCurrentAnimation, SkeletonObject), &setAnimationName, &getAnimationName, &writeAnimationName, "The animation name to play.");
     addProtectedField("Skin", TypeString, Offset(mCurrentSkin, SkeletonObject), &setCurrentSkin, &getCurrentSkin, &writeCurrentSkin, "The skin to use.");
-    addProtectedField("RootBoneScale", TypeVector2, NULL, &setRootBoneScale, &getRootBoneScale, &writeRootBoneScale, "Scaling of the skeleton's root bone");
-    addProtectedField("RootBoneOffset", TypeVector2, NULL, &setRootBoneOffset, &getRootBoneOffset, &writeRootBoneOffset, "X/Y offset of the skeleton's root bone");
+    addProtectedField("RootBoneScale", TypeVector2, 0, &setRootBoneScale, &getRootBoneScale, &writeRootBoneScale, "Scaling of the skeleton's root bone");
+    addProtectedField("RootBoneOffset", TypeVector2, 0, &setRootBoneOffset, &getRootBoneOffset, &writeRootBoneOffset, "X/Y offset of the skeleton's root bone");
     addProtectedField("AnimationCycle", TypeBool, Offset(mAnimationCycle, SkeletonObject), &setAnimationCycle, &defaultProtectedGetFn, &writeAnimationCycle, "Whether the animation loops or not");
     addField("FlipX", TypeBool, Offset(mFlipX, SkeletonObject), &writeFlipX, "");
     addField("FlipY", TypeBool, Offset(mFlipY, SkeletonObject), &writeFlipY, "");

--- a/engine/source/Box2D/Collision/Shapes/b2ChainShape.h
+++ b/engine/source/Box2D/Collision/Shapes/b2ChainShape.h
@@ -95,8 +95,8 @@ inline b2ChainShape::b2ChainShape()
 	m_radius = b2_polygonRadius;
 	m_vertices = NULL;
 	m_count = 0;
-	m_hasPrevVertex = NULL;
-	m_hasNextVertex = NULL;
+	m_hasPrevVertex = false;
+	m_hasNextVertex = false;
 }
 
 #endif

--- a/engine/source/gui/guiTextEditCtrl.cc
+++ b/engine/source/gui/guiTextEditCtrl.cc
@@ -113,7 +113,7 @@ bool GuiTextEditCtrl::onAdd()
       }
    }
 
-   if( mText && mText[0] )
+   if( mText[0] )
    {
       setText(mText);
    }

--- a/engine/source/io/fileObject.cc
+++ b/engine/source/io/fileObject.cc
@@ -58,7 +58,7 @@ bool FileObject::openForWrite(const char *fileName, const bool append)
 
    close();
 
-   if(buffer == NULL || *buffer == 0)
+   if(*buffer == 0)
       return false;
 
    if ( !append )

--- a/engine/source/io/fileSystem_ScriptBinding.cc
+++ b/engine/source/io/fileSystem_ScriptBinding.cc
@@ -240,7 +240,7 @@ ConsoleFunctionWithDocs(isWriteableFileName, ConsoleBool, 2, 2, (fileName))
    char filename[1024];
    Con::expandPath(filename, sizeof(filename), argv[1]);
 
-   if (filename == NULL || *filename == 0)
+   if (*filename == 0)
       return false;
 
    // in a writeable directory?

--- a/engine/source/persistence/SimXMLDocument.cpp
+++ b/engine/source/persistence/SimXMLDocument.cpp
@@ -129,7 +129,7 @@ S32 SimXMLDocument::saveFile(const char* rFileName)
    char buffer[1024];
    Con::expandPath(buffer, sizeof(buffer), rFileName);
 
-   if(buffer == NULL || *buffer == 0)
+   if(*buffer == 0)
       return false;
 
    FileStream strm;


### PR DESCRIPTION
These are changes to fix various compiler warnings generated when I was fixing Android Studio build problems, but aren't specific to Android. Note that this doesn't necessarily fix all warnings for other platforms such as other platforms respective source files.
