### PR TITLE
More dStrstr usage fixes

### DIFF
--- a/engine/source/gui/guiMessageVectorCtrl.cc
+++ b/engine/source/gui/guiMessageVectorCtrl.cc
@@ -302,7 +302,7 @@ void GuiMessageVectorCtrl::createSpecialMarkers(SpecialMarkers& rSpecial, const 
          matchBuffer[499] = '\0';
          dStrcat(matchBuffer, "://");
 
-         const char* pMatch = dStrstr(pCurr, (const char*)matchBuffer);
+         const char* pMatch = dStrstr(pCurr, matchBuffer);
          if (pMatch != NULL && pMatch < pMinMatch) {
             pMinMatch = pMatch;
             minMatchType = i;

--- a/engine/source/network/serverQuery.cc
+++ b/engine/source/network/serverQuery.cc
@@ -1932,7 +1932,7 @@ static void handleGameInfoResponse( const NetAddress* address, BitStream* stream
    // Get the mission name:
    stream->readString( stringBuf );
    // Clip the file extension off:
-   char* temp = dStrstr( static_cast<char*>( stringBuf ), const_cast<char*>( ".mis" ) );
+   char* temp = dStrstr( stringBuf, ".mis" );
    if ( temp )
       *temp = '\0';
    if ( !si->missionName || dStrcmp( si->missionName, stringBuf ) != 0 )

--- a/engine/source/platformOSX/osxCocoaUtilities.mm
+++ b/engine/source/platformOSX/osxCocoaUtilities.mm
@@ -55,7 +55,7 @@
         else
         {
             // detect *.*
-            if (dStrstr((const char *) token, "*.*"))
+            if (dStrstr(token, "*.*"))
             {
                 fileTypes.any = true;
             }

--- a/engine/source/platformWin32/winWindow.cc
+++ b/engine/source/platformWin32/winWindow.cc
@@ -1718,9 +1718,9 @@ bool Platform::openWebBrowser( const char* webAddress )
       convertUTF16toUTF8(sWebKey,utf8WebKey,512);
 
 #ifdef UNICODE
-      char *p = dStrstr((const char *)utf8WebKey, "%1"); 
+      char *p = dStrstr(utf8WebKey, "%1"); 
 #else
-      char *p = dStrstr( (const char *) sWebKey  , "%1"); 
+      char *p = dStrstr(sWebKey, "%1"); 
 #endif
       if (p) *p = 0; 
 


### PR DESCRIPTION
More dStrstr usage fixes
Overall a few compiler error fixes for compilers that are more strict. And removed unnecessary const casting of the second argument as its always const now in `dStrstr` prototype to conform to stdlib's `strstr` since PR #405 

Note that I'm intentionally being hypocritical here for not changing OpenGL extension checks code that does the unnecessary second argument const casting, but figured those don't really cause any harm it is consistent across all platforms' OpenGL initialization code and doesn't generate any compiler warnings.
